### PR TITLE
Route level whitelisting

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@
 
 ## Usage
 
-express-winston provides middlewares for request and error logging of your express.js application.
+express-winston provides middlewares for request and error logging of your express.js application.  It uses 'whitelists' to select properties from the request and (new in 0.2.x) response objects.
 
 ### Error Logging
 
@@ -53,7 +53,7 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
     app.use(app.router); // notice how the router goes after the logger.
 ```
 
-## Example
+## Examples
 
 ``` js
     var express = require('express');
@@ -210,13 +210,55 @@ Browse `/error` will show you how express-winston handles and logs the errors in
       "message": "middlewareError"
     }
 
+## Whitelists
+New in version 0.2.x is the ability to add whitelist elements in a route.  express-winston adds a `_routeWhitelists` object to the `req`uest, containing `.body`, `.req` and .res` properties, to which you can set an array of 'whitelist' parameters to include in the log, specific to the route in question:
+
+``` js
+    app.post('/user/register', function(req, res, next) {
+      req._routeWhitelists.body = ['username', 'email', 'age']; // But not 'password' or 'confirm-password' or 'top-secret'
+      req._routeWhitelists.res = ['_headers'];
+    });
+```
+
+Post to `/user/register` would give you something like the following:
+
+    {
+      "req": {
+        "httpVersion": "1.1",
+        "headers": {
+          "host": "localhost:3000",
+          "connection": "keep-alive",
+          "accept": "*/*",
+          "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/536.11 (KHTML, like Gecko) Chrome/20.0.1132.57 Safari/536.11",
+          "accept-encoding": "gzip,deflate,sdch",
+          "accept-language": "en-US,en;q=0.8,es-419;q=0.6,es;q=0.4",
+          "accept-charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.3",
+          "cookie": "connect.sid=nGspCCSzH1qxwNTWYAoexI23.seE%2B6Whmcwd"
+        },
+        "url": "/",
+        "method": "GET",
+        "originalUrl": "/",
+        "query": {},
+        "body": {
+          "username": "foo",
+          "email": "foo@bar.com",
+          "age": "72"
+        }
+      },
+      "res": {
+        "statusCode": 200
+      },
+      "responseTime" : 12,
+      "level": "info",
+      "message": "HTTP GET /favicon.ico"
+    }
+
 ## Tests
 
     npm test
 
 ## Issues and Collaboration
 
-* Add support for filtering of __req.body__. At this moment `body` is not included in the logging because it can contain sensitive fields like 'password' or 'password_confirmation'.
 * Implement a chain of requestFilters. Currently only one requestFilter is allowed in the options.
 
 We are accepting pull-request for these features.
@@ -225,8 +267,9 @@ If you ran into any problems, please use the project [Issues section](https://gi
 
 ## Contributors
 
-* [Johan Hernandez](https://github.com/thepumpkin1979). [https://github.com/thepumpkin1979](https://github.com/thepumpkin1979)
-* [Lars Jacob]((https://github.com/jaclar)) [https://github.com/jaclar)](https://github.com/jaclar)
+* [Johan Hernandez](https://github.com/thepumpkin1979) (https://github.com/thepumpkin1979)
+* [Lars Jacob](https://github.com/jaclar) (https://github.com/jaclar)
+* [Jonathan Lomas](https://github.com/floatingLomas) (https://github.com/floatingLomas)
 
 ## MIT License
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "express-winston",
   "description": "express.js middleware for flatiron/winston",
   "keywords": ["winston", "flatiron", "logging", "express", "log", "error", "handler", "middleware"],
-  "version": "0.1.3",
+  "version": "0.2.0",
   "repository": {
     "url": "https://github.com/firebaseco/express-winston.git"
   },
@@ -22,7 +22,7 @@
   },
 	"licenses" : [
 		{
-			"type" : "MIT", 
+			"type" : "MIT",
 			"url" : "https://github.com/firebaseco/express-winston/blob/master/LICENSE"
 		}
 	]

--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,9 @@ vows.describe("exports").addBatch({
     "an array with all the properties whitelisted in the res object": function(exports) {
       assert.isArray(exports.responseWhitelist);
     },
+    "an array with all the properties whitelisted in the body object": function(exports) {
+      assert.isArray(exports.bodyWhitelist);
+    },
     "and the factory should contain a default request filter function": function(exports) {
       assert.isFunction(exports.defaultRequestFilter);
     },
@@ -149,7 +152,7 @@ vows.describe("errorLogger").addBatch({
   }
 }).export(module);
 
-vows.describe("logger").addBatch({
+vows.describe("logger 0.1.x").addBatch({
   "when I run the middleware factory": {
     topic: function() {
       return expressWinston.logger;
@@ -205,14 +208,10 @@ vows.describe("logger").addBatch({
         params: {
           id: 20
         },
-        nonWhitelistedProperty: "value that should not be logged"
+        filteredProperty: "value that should not be logged"
       };
       var res = {
-        statusCode: 200,
-        nonWhitelistedProperty: "value that should not be logged",
-        end: function(chunk, encoding) {
-
-        }
+        end: function(chunk, encoding) {}
       };
       var test = {
         req: req,
@@ -220,7 +219,6 @@ vows.describe("logger").addBatch({
         log: {}
       };
       var next = function(_req, _res, next) {
-        req._startTime = (new Date) - 125;
         res.end();
         return callback(null, test);
       };
@@ -249,30 +247,138 @@ vows.describe("logger").addBatch({
       assert.deepEqual(result.log.meta.req.query, {
                       val: '2'
       });
+      assert.isUndefined(result.log.meta.req.filteredProperty);
+    }
+  }
+}).export(module);
+
+vows.describe("logger 0.2.x").addBatch({
+  "when I run the middleware factory": {
+    topic: function() {
+      return expressWinston.logger;
+    },
+    "without options": {
+      "an error should be raised": function(factory) {
+        assert.throws(function() {
+          factory();
+        }, Error);
+      }
+    },
+    "without any transport specified": {
+      "an error should be raised": function(factory) {
+        assert.throws(function() {
+          factory({});
+        }, Error);
+      }
+    },
+    "with an empty list of transports": {
+      "an error should be raised": function(factory) {
+        assert.throws(function() {
+          factory({transports:[]});
+        }, Error);
+      }
+    },
+    "with proper options": {
+      "the result should be a function with three arguments that fit req, res, next": function (factory) {
+        var middleware = factory({
+          transports: [
+            new MockTransport({
+
+            })
+          ]
+        });
+        assert.equal(middleware.length, 3);
+      }
+    }
+  },
+  "When the express-winston middleware is invoked in pipeline": {
+    topic: function() {
+      var factory = expressWinston.logger;
+      var callback = this.callback;
+      var req = {
+        url: "/hello?val=1",
+        headers: {
+          'header-1': 'value 1'
+        },
+        method: 'GET',
+        query: {
+          val: '2'
+        },
+        originalUrl: "/hello?val=2",
+        params: {
+          id: 20
+        },
+        nonWhitelistedProperty: "value that should not be logged",
+        routeLevelAddedProperty: "value that should be logged",
+        body: {
+          username: 'bobby',
+          password: 'top-secret'
+        }
+      };
+      var res = {
+        statusCode: 200,
+        nonWhitelistedProperty: "value that should not be logged",
+        routeLevelAddedProperty: "value that should be logged",
+        end: function(chunk, encoding) {
+
+        }
+      };
+      var test = {
+        req: req,
+        res: res,
+        log: {}
+      };
+      var next = function(_req, _res, next) {
+        req._startTime = (new Date) - 125;
+
+        req._routeWhitelists.req = [ 'routeLevelAddedProperty' ];
+        req._routeWhitelists.body = [ 'username' ];
+
+        res.end();
+        return callback(null, test);
+      };
+
+      var transport = new MockTransport({});
+      transport.log = function(level, msg, meta, cb) {
+        test.transportInvoked = true;
+        test.log.level = level;
+        test.log.msg = msg;
+        test.log.meta = meta;
+        this.emit('logged');
+        return cb();
+      };
+      var middleware = factory({
+        transports: [transport]
+      });
+      middleware(req, res, next);
+    }
+    , "then the transport should be invoked": function(result){
+      assert.isTrue(result.transportInvoked);
+    }
+    , "the meta should contain a filtered request": function(result){
+      assert.isTrue(!!result.log.meta.req, "req should be defined in meta");
+      assert.isNotNull(result.log.meta.req);
+      assert.equal(result.log.meta.req.method, "GET");
+      assert.deepEqual(result.log.meta.req.query, { val: '2' });
       assert.isUndefined(result.log.meta.req.nonWhitelistedProperty);
+
+      assert.isNotNull(result.log.meta.req.routeLevelAddedProperty);
+    }
+    , "the meta should contain a filtered request body": function(result) {
+      assert.deepEqual(result.log.meta.req.body, {username: 'bobby'});
+      assert.isUndefined(result.log.meta.req.body.password);
     }
     , "the meta should contain a filtered response": function(result){
       assert.isTrue(!!result.log.meta.res, "res should be defined in meta");
       assert.isNotNull(result.log.meta.res);
       assert.equal(result.log.meta.res.statusCode, 200);
-      assert.isUndefined(result.log.meta.req.nonWhitelistedProperty);
+      assert.isNotNull(result.log.meta.res.routeLevelAddedProperty);
     }
     , "the meta should contain a response time": function(result){
       assert.isTrue(!!result.log.meta.responseTime, "responseTime should be defined in meta");
       assert.isNotNull(result.log.meta.responseTime);
       assert.isTrue(result.log.meta.responseTime > 120);
       assert.isTrue(result.log.meta.responseTime < 130);
-    }
-    , "the meta should contain a filtered response": function(result){
-      assert.isTrue(!!result.log.meta.res, "res should be defined in meta");
-      assert.isNotNull(result.log.meta.res);
-      assert.equal(result.log.meta.res.statusCode, 200);
-      assert.isUndefined(result.log.meta.req.filteredProperty);
-    }
-    , "the meta should contain a response time": function(result){
-      assert.isTrue(!!result.log.meta.responseTime, "responseTime should be defined in meta");
-      assert.isNotNull(result.log.meta.responseTime);
-      assert.equal(result.log.meta.responseTime, 125);
     }
   }
 }).export(module);


### PR DESCRIPTION
Ok, so as requested, I added myself to the README.md, added some (hopefully-informative) content to it, and bumped the version to 0.2.0, because...

...I also added 'route-level whitelisting' so that you can add items at the express route handler level to whitelist any relevant `req.body` properties or add any additional relevant `req` or `res` properties.  I think this covers off your 'how do we log from the request body safely' feature request.  

I added a `logger 0.1.x` test batch that exactly(1) matches the tests before I started mucking around so that I could ensure backwards-compatibility.  These tests, along with the new tests, all pass.

If you have any issues or concernts with any of it, let me know.

_1) I had to tweak them because the logger now makes use of res.end() (how it catches the response stuff and does the response timer), but other than that, it's identical._
