### PR TITLE
Prevent underscore template settings from affecting other underscore usages in the process

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,11 @@
 //
 var winston = require('winston');
 var util = require('util');
+
+//Allow this file to get an exclusive copy of underscore so it can change the template settings without affecting others
+delete require.cache[require.resolve('underscore')];
 var _ = require('underscore');
+delete require.cache[require.resolve('underscore')];
 
 /**
  * A default list of properties in the request object that are allowed to be logged.


### PR DESCRIPTION
I opted for this technique instead of simply reverting the template setting after using it because that would have required a try / finally to be error tolerant. I don't think those optimize well currently with V8, and I figured performance is fairly important to a logging component.
