### PR TITLE
allow winston 0.7 transports

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,9 +147,9 @@ function logger(options) {
             res.end = end;
             res.end(chunk, encoding);
 
+            var meta = {};
+            
             if(options.meta !== false) {
-              var meta = {};
-
               var bodyWhitelist;
 
               requestWhitelist = requestWhitelist.concat(req._routeWhitelists.req || []);


### PR DESCRIPTION
If a Winston 0.7 transport is passed in, log messages have " undefined" appended to them.  Fix.
