### PR TITLE
Use WinstonLogger.log rather than transport.log

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,11 +55,14 @@ The logger needs to be added AFTER the express router(`app.router)`) and BEFORE 
 
 ``` js
     transports: [<WinstonTransport>], // list of all winston transports instances to use.
+    winstonInstance: <WinstonLogger>, // a winston logger instance. If this is provided the transports option is ignored
     level: String, // log level to use, the default is "info".
     statusLevels: Boolean // different HTTP status codes caused log messages to be logged at different levels (info/warn/error), the default is false
 ```
 
 To use winston's existing transports, set `transports` to the values (as in key-value) of the `winston.default.transports` object. This may be done, for example, by using underscorejs: `transports: _.values(winston.default.transports)`.
+
+Alternatively, if you're using a winston logger instance elsewhere and have already set up levels and transports, pass the instance into expressWinston with the `winstonInstance` option. The `transports` option is then ignored.
 
 ### Request Logging
 

--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ function errorLogger(options) {
     ensureValidOptions(options);
 
     options.requestFilter = options.requestFilter || defaultRequestFilter;
+    options.winstonInstance = options.winstonInstance || (new winston.Logger ({ transports: options.transports }));
 
     return function (err, req, res, next) {
 
@@ -105,12 +106,9 @@ function errorLogger(options) {
         exceptionMeta.req = filterObject(req, requestWhitelist, options.requestFilter);
 
         // This is fire and forget, we don't want logging to hold up the request so don't wait for the callback
-        for(var i = 0; i < options.transports.length; i++) {
-            var transport = options.transports[i];
-            transport.logException('middlewareError', exceptionMeta, function () {
-                // Nothing to do here
-            });
-        }
+        options.winstonInstance.log('error', 'middlewareError', exceptionMeta, function () {
+            // Nothing to do here
+        });
 
         next(err);
     };
@@ -128,6 +126,7 @@ function logger(options) {
 
     options.requestFilter = options.requestFilter || defaultRequestFilter;
     options.responseFilter = options.responseFilter || defaultResponseFilter;
+    options.winstonInstance = options.winstonInstance || (new winston.Logger ({ transports: options.transports }));
     options.level = options.level || "info";
     options.statusLevels = options.statusLevels || false;
     options.msg = options.msg || "HTTP {{req.method}} {{req.url}}";
@@ -184,12 +183,9 @@ function logger(options) {
             var msg = template({req: req, res: res});
 
             // This is fire and forget, we don't want logging to hold up the request so don't wait for the callback
-            for(var i = 0; i < options.transports.length; i++) {
-                var transport = options.transports[i];
-                transport.log(options.level, msg, meta, function () {
-                    // Nothing to do here
-                });
-            }
+            options.winstonInstance.log(options.level, msg, meta, function () {
+                // Nothing to do here
+            });
         };
 
         next();
@@ -198,7 +194,8 @@ function logger(options) {
 
 function ensureValidOptions(options) {
     if(!options) throw new Error("options are required by express-winston middleware");
-    if(!options.transports || !(options.transports.length > 0)) throw new Error("transports are required by express-winston middleware");
+    if(!((options.transports && (options.transports.length > 0)) || options.winstonInstance))
+        throw new Error("transports or a winstonInstance are required by express-winston middleware");
 };
 
 module.exports.errorLogger = errorLogger;


### PR DESCRIPTION
Winston allows transports to be given a 'level' option - this allows you to prevent more noisy message levels (e.g. debug / info) from being sent to transports that only want to know about errors for example.

Previously this option was ignored as the dispatch of messages to winston transports inside expressWinston was done manually. I've changed this to use winston's own dispatching method, inside WinstonLogger.log, which obeys the level threshold rules.

As a winston logger instance is created for this purpose, I've also allowed the user to pass in a winstonLogger instance in the options. This saves the user from configuring all the transports transports twice, and also allows access to the winstonLogger's own configuration options if needed.
