### PR TITLE
Log response body

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,6 +166,9 @@ function logger(options) {
 
               meta.req = filterObject(req, requestWhitelist, options.requestFilter);
               meta.res = filterObject(res, responseWhitelist, options.responseFilter);
+              if (_.contains(responseWhitelist, 'body')) {
+                  meta.res.body = res._headers['content-type'].indexOf('json') >= 0 ? JSON.parse(chunk) : chunk;
+              }
 
               bodyWhitelist = req._routeWhitelists.body || [];
 


### PR DESCRIPTION
And one more. To log the response body, I have introduced the magic whitelist item 'body' for the response whitelist. If it is present in the whitelist, the content of the response (variable 'chunk' in the code) will be added as value to the property 'body'. If the content type of the response contains 'json' it will be parsed before adding it.

If you approve I can update the README. So far, no documentation. I have tested this in my code were I require it. It works for my case (using JSON and string repsonses).

Cheers,
Chantal
