### PR TITLE
Fix Readme.md error

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -130,7 +130,7 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
     });
 
     app.listen(3000, function(){
-      console.log("express-winston demo listening on port %d in %s mode", app.address().port, app.settings.env);
+      console.log("express-winston demo listening on port %d in %s mode", this.address().port, app.settings.env);
     });
 ```
 


### PR DESCRIPTION
In express > 3 the app is no longer a http server object. To access the object one should just access "this" in the app.listen callback.
