### PR TITLE
PR 37 - blocking certain routes, unit tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,13 @@ var bodyBlacklist = [];
 var responseWhitelist = ['statusCode'];
 
 /**
+ * A list of request routes that will be skipped instead of being logged. This would be useful if routes for health checks or pings would otherwise pollute
+ * your log files.
+ * @type {Array}
+ */
+var ignoredRoutes = [];
+
+/**
  * A default function to filter the properties of the req object.
  * @param req
  * @param propName
@@ -141,6 +148,11 @@ function logger(options) {
     options.expressFormat = options.expressFormat || false;
 
     return function (req, res, next) {
+
+        if (_.contains(ignoredRoutes, _.isObject(req._parsedUrl) && req._parsedUrl.pathname)) {
+          return next();
+        }
+
 
         req._startTime = (new Date);
 
@@ -238,3 +250,4 @@ module.exports.bodyBlacklist = bodyBlacklist;
 module.exports.responseWhitelist = responseWhitelist;
 module.exports.defaultRequestFilter = defaultRequestFilter;
 module.exports.defaultResponseFilter = defaultResponseFilter;
+module.exports.ignoredRoutes = ignoredRoutes;


### PR DESCRIPTION
For https://github.com/bithavoc/express-winston/issues/37
- exposing an ignoredRoutes array, similar to how some other whitelists/blacklists are handled
- refactored unit tests to be somewhat more DRY, added unit test for 0.1.x to test ignoredRoutes, not sure what's different between 0.1.x and 0.2.x
- forgot to update README.md - if this actually has a chance of getting merged, I can update the documentation for ignoredRoutes
