### PR TITLE
Updating travis config to Node 0.10 and 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "0.6"
-  - "0.8"
+  - "0.10"
+  - "0.11"
 script: "npm test"


### PR DESCRIPTION
Seems the travis run is broken for 0.6 and 0.8. Should really be testing 0.10 and 0.11 anyway, those other versions are ancient! :)
