### PR TITLE
Convert tests to Mocha with Should

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 #################
 .DS_Store
 lib/.DS_Store
+coverage.html

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/.bin/vows --spec"
+    "test": "node_modules/.bin/mocha -R spec"
   },
   "dependencies": {
     "chalk": "~0.4.0",
@@ -36,8 +36,9 @@
     "winston": "0.7.x"
   },
   "devDependencies": {
+    "mocha": "~2.1.0",
     "node-mocks-http": "~1.2.3",
-    "vows": "0.7.x"
+    "should": "~4.6.0"
   },
   "engines": {
     "node": ">=0.6.0"


### PR DESCRIPTION
As discussed in #54, coverage will have to wait for removing Node 0.6 support because the coverage tools all require >=0.8

Have a look and let me know what you think - there's no rush on this one.  If any other PRs get merged in I'll rebase this to include them.

For what it's worth, coverage is currently at 89%, so not too shabby.