### PR TITLE
expressFormat use originalUrl if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ function logger(options) {
             }
 
             if(options.expressFormat) {
-              var msg = chalk.grey(req.method+" "+req.url)+" "+chalk[statusColor](res.statusCode)+" "+chalk.grey(res.responseTime+"ms");
+              var msg = chalk.grey(req.method+" "+req.originalUrl || req.url)+" "+chalk[statusColor](res.statusCode)+" "+chalk.grey(res.responseTime+"ms");
             } else {
               // Using mustache style templating
               _.templateSettings = {


### PR DESCRIPTION
When using nested routers in e.g. express, the router modifies req.url to only contain the router relevant url part. For that matter, when logging req.url, you wouldn't see the complete original url. Express adds req.originalUrl which contains the url that was called by the client. If this property is available, it should be used over req.url in the log format