### PR TITLE
Add test coverage with Blanket.js to close #54

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 ## Node
 #################
 /node_modules
+npm-debug.log
 
 #################
 ## Jetbrains

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ node_js:
   - "0.8"
   - "0.10"
   - "0.11"
-script: "npm test"
+script:
+  - "test $TRAVIS_NODE_VERSION  = '0.6' || npm test"
+  - "test $TRAVIS_NODE_VERSION != '0.6' || npm run-script test-coverage"

--- a/Readme.md
+++ b/Readme.md
@@ -266,7 +266,7 @@ Only those properties of the request object will be logged. Set or modify the wh
 For example, to include the session property (the session data), add the following during logger setup:
 
     expressWinston.requestWhitelist.push('session');
-    
+
 The blacklisting excludes certain properties and keeps all others. If both `bodyWhitelist` and `bodyBlacklist` are set
 the properties excluded by the blacklist are not included even if they are listed in the whitelist!
 
@@ -318,14 +318,14 @@ Post to `/user/register` would give you something like the following:
       "level": "info",
       "message": "HTTP GET /favicon.ico"
     }
-    
+
 Blacklisting supports only the `body` property.
 
 
 ``` js
     router.post('/user/register', function(req, res, next) {
       req._routeWhitelists.body = ['username', 'email', 'age']; // But not 'password' or 'confirm-password' or 'top-secret'
-      req._routeBlacklists.body = ['username', 'password', 'confirm-password', 'top-secret']; 
+      req._routeBlacklists.body = ['username', 'password', 'confirm-password', 'top-secret'];
       req._routeWhitelists.res = ['_headers'];
     });
 ```
@@ -336,13 +336,19 @@ excluding any black listed ones. In the above example, only 'email' and 'age' wo
 
 ## Tests
 
+Run the basic Mocha tests:
+
     npm test
 
+Run the Travis-CI tests (which will fail with < 100% coverage):
+
+    npm test-travis
+
+Generate the `coverage.html` coverage report:
+
+    npm test-coverage
+
 ## Issues and Collaboration
-
-* Implement a chain of requestFilters. Currently only one requestFilter is allowed in the options.
-
-We are accepting pull-request for these features.
 
 If you ran into any problems, please use the project [Issues section](https://github.com/bithavoc/express-winston/issues) to search or post any bug.
 

--- a/package.json
+++ b/package.json
@@ -1,70 +1,82 @@
 {
-  "author": {
-    "name": "bithavoc",
-    "email": "im@bithavoc.io",
-    "url": "http://bithavoc.io"
-  },
-  "name": "express-winston",
-  "description": "express.js middleware for flatiron/winston",
-  "keywords": [
-    "winston",
-    "flatiron",
-    "logging",
-    "express",
-    "log",
-    "error",
-    "handler",
-    "middleware",
-    "colors"
-  ],
-  "version": "0.2.12",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/bithavoc/express-winston.git"
-  },
-  "bugs": {
-    "url": "http://github.com/bithavoc/express-winston/issues",
-    "email": "im@bithavoc.io"
-  },
-  "main": "index.js",
-  "scripts": {
-    "test": "node_modules/.bin/mocha -R spec"
-  },
-  "dependencies": {
-    "chalk": "~0.4.0",
-    "underscore": "~1.5.2",
-    "winston": "0.7.x"
-  },
-  "devDependencies": {
-    "mocha": "~2.1.0",
-    "node-mocks-http": "~1.2.3",
-    "should": "~4.6.0"
-  },
-  "engines": {
-    "node": ">=0.6.0"
-  },
-  "license": "MIT",
-  "contributors": [
-    {
-      "name": "Lars Jacob",
-      "url": "http://jaclar.net"
+    "author": {
+        "name": "bithavoc",
+        "email": "im@bithavoc.io",
+        "url": "http://bithavoc.io"
     },
-    {
-      "name": "Jonathan Lomas",
-      "url": "http://floatinglomas.ca"
+    "name": "express-winston",
+    "description": "express.js middleware for flatiron/winston",
+    "keywords": [
+        "winston",
+        "flatiron",
+        "logging",
+        "express",
+        "log",
+        "error",
+        "handler",
+        "middleware",
+        "colors"
+    ],
+    "version": "0.2.12",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/bithavoc/express-winston.git"
     },
-    {
-      "name": "Xavier Damman",
-      "url": "http://xdamman.com"
+    "bugs": {
+        "url": "http://github.com/bithavoc/express-winston/issues",
+        "email": "im@bithavoc.io"
     },
-    {
-      "name": "Quentin Rossetti",
-      "email": "quentin.rossetti@gmail.com"
+    "main": "index.js",
+    "scripts": {
+        "test": "node_modules/.bin/mocha --reporter spec",
+        "test-travis": "node_modules/.bin/mocha --require blanket --reporter travis-cov",
+        "test-coverage": "node_modules/.bin/mocha --require blanket --reporter html-cov >| coverage.html || true"
     },
-    {
-      "name": "Robbie Trencheny",
-      "email": "me@robbiet.us",
-      "url": "http://robbie.io"
-    }
-  ]
+    "config": {
+        "travis-cov": {
+            "threshold": 100
+        },
+        "blanket": {
+            "pattern": [
+                "index.js"
+            ],
+            "data-cover-never": [
+                "node_modules",
+                "test"
+            ]
+        }
+    },
+    "dependencies": {
+        "chalk": "~0.4.0",
+        "underscore": "~1.5.2",
+        "winston": "0.7.x"
+    },
+    "devDependencies": {
+        "blanket": "~1.1.6",
+        "mocha": "~2.1.0",
+        "node-mocks-http": "~1.2.3",
+        "should": "~4.6.0",
+        "travis-cov": "~0.2.5"
+    },
+    "engines": {
+        "node": ">=0.6.0"
+    },
+    "license": "MIT",
+    "contributors": [{
+        "name": "Lars Jacob",
+        "url": "http://jaclar.net"
+    }, {
+        "name": "Jonathan Lomas",
+        "url": "http://floatinglomas.ca"
+    }, {
+        "name": "Xavier Damman",
+        "url": "http://xdamman.com"
+    }, {
+        "name": "Quentin Rossetti",
+        "email": "quentin.rossetti@gmail.com"
+    }, {
+        "name": "Robbie Trencheny",
+        "email": "me@robbiet.us",
+        "url": "http://robbie.io"
+    }]
 }


### PR DESCRIPTION
- HTML Coverage report - `npm run-script test-coverage`
- Travis-CI test which fails if coverage < 100% - `npm run-script test-travis`

Also tweaked tests to provide 100% coverage, updated `.travis.yml` to only run
`test-travis` script if Node version > 0.6, updated Readme.md to make note of
test changes.

And yet more, move underscore template settings into `_.template()`
instead of overriding underscore settings, which should resolve #17