### PR TITLE
Bump up winston version to solve nsp security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "dependencies": {
         "chalk": "~0.4.0",
         "underscore": "~1.5.2",
-        "winston": "0.7.x"
+        "winston": "~0.9.0"
     },
     "devDependencies": {
         "blanket": "~1.1.6",


### PR DESCRIPTION
The node security project picked up a vuln in express-winston, from qs (obtained from express 0.7.3). 

I've run the test and everything passes. Had a look in the changelog of winston and saw no breaking changes. But you might have a better feel for what to look out for on this.

Thanks