### PR TITLE
allow to ignore routes based on req and res

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -83,7 +83,8 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
       meta: true, // optional: control whether you want to log the meta data about the request (default to true)
       msg: "HTTP {{req.method}} {{req.url}}", // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
       expressFormat: true, // Use the default Express/morgan request formatting, with the same colors. Enabling this will override any msg and colorStatus if true. Will only output colors on transports with colorize set to true
-      colorStatus: true // Color the status code, using the Express/morgan color palette (default green, 3XX cyan, 4XX yellow, 5XX red). Will not be recognized if expressFormat is true
+      colorStatus: true, // Color the status code, using the Express/morgan color palette (default green, 3XX cyan, 4XX yellow, 5XX red). Will not be recognized if expressFormat is true
+      ignoreRoute: function (req, res) { return false; } // optional: allows to skip some log messages based on request and/or response
     }));
 
     app.use(router); // notice how the router goes after the logger.


### PR DESCRIPTION
Added an optional ignoreRoute option that expects a function that receives req and res as params and should return true when the request should be ignored (= not logged), false otherwise.
IgnoredRoutes now also uses req.originalUrl or url instead of req.path, which should fix #63