### PR TITLE
Skip option added

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,6 +60,7 @@ The logger needs to be added AFTER the express router(`app.router)`) and BEFORE 
     winstonInstance: <WinstonLogger>, // a winston logger instance. If this is provided the transports option is ignored
     level: String, // log level to use, the default is "info".
     statusLevels: Boolean // different HTTP status codes caused log messages to be logged at different levels (info/warn/error), the default is false
+    skip: function(req, res) // function to determine if logging is skipped, defaults to false
 ```
 
 To use winston's existing transports, set `transports` to the values (as in key-value) of the `winston.default.transports` object. This may be done, for example, by using underscorejs: `transports: _.values(winston.default.transports)`.

--- a/index.js
+++ b/index.js
@@ -83,6 +83,14 @@ var defaultResponseFilter = function (req, propName) {
     return req[propName];
 };
 
+/**
+ * A default function to decide whether skip logging of particular request. Doesn't skip anything (i.e. log all requests).
+ * @return always false
+ */
+var defaultSkip = function() {
+  return false;
+};
+
 function filterObject(originalObj, whiteList, initialFilter) {
 
     var obj = {};
@@ -146,6 +154,7 @@ function logger(options) {
     options.colorStatus = options.colorStatus || false;
     options.expressFormat = options.expressFormat || false;
     options.ignoreRoute = options.ignoreRoute || function () { return false; };
+    options.skip = options.skip || defaultSkip;
 
     // Using mustache style templating
     var template = _.template(options.msg, null, {
@@ -237,7 +246,9 @@ function logger(options) {
               var msg = template({req: req, res: res});
             }
             // This is fire and forget, we don't want logging to hold up the request so don't wait for the callback
-            options.winstonInstance.log(options.level, msg, meta);
+            if (!options.skip(req, res)) {
+              options.winstonInstance.log(options.level, msg, meta);
+            }
         };
 
         next();
@@ -264,4 +275,5 @@ module.exports.bodyBlacklist = bodyBlacklist;
 module.exports.responseWhitelist = responseWhitelist;
 module.exports.defaultRequestFilter = defaultRequestFilter;
 module.exports.defaultResponseFilter = defaultResponseFilter;
+module.exports.defaultSkip = defaultSkip;
 module.exports.ignoredRoutes = ignoredRoutes;


### PR DESCRIPTION
`Skip` option added with same behavior as in https://github.com/expressjs/morgan. Function to determine if logging is skipped, defaults to `false`. This function
will be called as `skip(req, res)`.

```js
app.use(expressWinston.logger({
  transports: ...
  skip: function(req, res) { return res.statusCode < 400 }
}));
```