### PR TITLE
expressFormat use originalUrl if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,7 +227,7 @@ function logger(options) {
             }
 
             if(options.expressFormat) {
-              var msg = chalk.grey(req.method + " " + req.url)
+              var msg = chalk.grey(req.method + " " + req.url || req.url)
                 + " " + chalk[statusColor](res.statusCode)
                 + " " + chalk.grey(res.responseTime+"ms");
             } else {


### PR DESCRIPTION
When using nested routers in e.g. express, the router modifies req.url to only contain the router relevant url part. For that matter, when logging req.url, you wouldn't see the complete original url. Express adds req.originalUrl which contains the url that was called by the client. If this property is available, it should be used over req.url in the log format

> NOTE: replaces @benkroeger's PR #57 which wouldn't merge because of silly changes 