### PR TITLE
Use req.originalUrl instead of req.url when available

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,6 +186,8 @@ function logger(options) {
             res.end = end;
             res.end(chunk, encoding);
 
+            req.url = req.originalUrl || req.url;
+
             if (options.statusLevels) {
               if (res.statusCode >= 100) { options.level = "info"; }
               if (res.statusCode >= 400) { options.level = "warn"; }


### PR DESCRIPTION
Fixes the problems with nested routers (see #57) in default and express formats. 