### PR TITLE
Support "combined" (CLF) log format

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -84,6 +84,7 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
       meta: true, // optional: control whether you want to log the meta data about the request (default to true)
       msg: "HTTP {{req.method}} {{req.url}}", // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
       expressFormat: true, // Use the default Express/morgan request formatting, with the same colors. Enabling this will override any msg and colorStatus if true. Will only output colors on transports with colorize set to true
+      clfFormat: true, // Use the "combined" Express/morgan request formatting, no colors
       colorStatus: true, // Color the status code, using the Express/morgan color palette (default green, 3XX cyan, 4XX yellow, 5XX red). Will not be recognized if expressFormat is true
       ignoreRoute: function (req, res) { return false; } // optional: allows to skip some log messages based on request and/or response
     }));

--- a/clf-date.js
+++ b/clf-date.js
@@ -1,0 +1,32 @@
+/**
+ * Array of CLF month names.
+ * @private
+ */
+
+var clfmonth = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ];
+
+/**
+ * Format a Date in the common log format.
+ *
+ * @private
+ * @param {Date} dateTime
+ * @return {string}
+ */
+function clfdate(dateTime) {
+    var date = dateTime.getUTCDate();
+    var hour = dateTime.getUTCHours();
+    var mins = dateTime.getUTCMinutes();
+    var secs = dateTime.getUTCSeconds();
+    var year = dateTime.getUTCFullYear();
+
+    var month = clfmonth[dateTime.getUTCMonth()];
+
+    return pad2(date) + '/' + month + '/' + year + ':' + pad2(hour) + ':' + pad2(mins) + ':' + pad2(secs) + ' +0000';
+}
+
+function pad2(num) {
+    var str = String(num);
+    return (str.length === 1 ? '0' : '') + str;
+}
+
+module.exports = clfdate;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     }
   },
   "dependencies": {
+    "basic-auth": "1.0.0",
     "chalk": "~0.4.0",
     "underscore": "~1.5.2",
     "winston": "~0.9.0"

--- a/test/test.js
+++ b/test/test.js
@@ -518,7 +518,7 @@ describe('expressWinston', function () {
       describe('log.msg', function () {
         var result;
 
-        function logMsgSetup(url, msg, expressFormat, done) {
+        function logMsgSetup(url, msg, expressFormat, clfFormat, done) {
           setUp({
             url: url || '/an-url'
           });
@@ -549,6 +549,10 @@ describe('expressWinston', function () {
             delete loggerOptions.msg;
             loggerOptions.expressFormat = true;
           }
+          if (clfFormat) {
+            delete loggerOptions.msg;
+            loggerOptions.clfFormat = true;
+          }
 
           var middleware = expressWinston.logger(loggerOptions);
 
@@ -558,7 +562,7 @@ describe('expressWinston', function () {
         describe('when default', function () {
 
           before(function (done) {
-            logMsgSetup('/url-of-sandwich', null, false, done);
+            logMsgSetup('/url-of-sandwich', null, false, false, done);
           });
 
           it('should match the custom format', function () {
@@ -568,7 +572,7 @@ describe('expressWinston', function () {
 
         describe('using Express format', function () {
           before(function (done) {
-            logMsgSetup('/all-the-things', null, true, done);
+            logMsgSetup('/all-the-things', null, true, false, done);
           });
 
           it('should match the Express format', function () {
@@ -578,9 +582,23 @@ describe('expressWinston', function () {
           });
         });
 
+        describe('using CLF format', function () {
+          before(function (done) {
+            logMsgSetup('/all-the-things', null, false, true, done);
+          });
+
+          it('should match the CLF format', function () {
+            var resultMsg = result.log.msg;
+
+            // timestamp in the middle
+            resultMsg.should.startWith('- - - [');
+            resultMsg.should.endWith('] "GET /all-the-things HTTP/" 200 - "-" "-" -ms');
+          });
+        });
+
         describe('when customized', function () {
           before(function (done) {
-            logMsgSetup('/all-the-things', 'Foo {{ req.method }} {{ req.url }}', false, done);
+            logMsgSetup('/all-the-things', 'Foo {{ req.method }} {{ req.url }}', false, false, done);
           });
 
           it('should match the custom format', function () {
@@ -588,7 +606,7 @@ describe('expressWinston', function () {
           });
         });
       });
-      
+
       describe('log.skip', function () {
         var result;
 


### PR DESCRIPTION
I've took the implementation from #72, rebased it on top of master, dropped most of the (questionable) `package.json` changes, adjusted the implementation based on the review (mostly renaming to `clfFormat`), extracted the datetime helper into a separate module and added a primitive test, which just verifies the current output.

I've also tested this in my own application, where it seems to work fine. I'm not sure how good the actual log format is, so the test may just confirm that the implementation is wrong.

As to the question from #72 why "basic-auth" is needed: Its used to output the ":remote-user" part, as far as I can tell.