### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,13 +228,15 @@ function logger(options) {
 
               var filteredBody = null;
 
-              if (blacklist.length > 0 && bodyWhitelist.length === 0) {
-                var whitelist = _.difference(_.keys(req.body), blacklist);
-                filteredBody = filterObject(req.body, whitelist, options.requestFilter);
-              } else {
-                filteredBody = filterObject(req.body, bodyWhitelist, options.requestFilter);
+              if ( req.body !== undefined ) {
+                  if (blacklist.length > 0 && bodyWhitelist.length === 0) {
+                    var whitelist = _.difference(_.keys(req.body), blacklist);
+                    filteredBody = filterObject(req.body, whitelist, options.requestFilter);
+                  } else {
+                    filteredBody = filterObject(req.body, bodyWhitelist, options.requestFilter);
+                  }
               }
-
+              
               if (filteredBody) meta.req.body = filteredBody;
 
               meta.responseTime = res.responseTime;


### PR DESCRIPTION
Added check if body is set. Before the fix, I had the following for some requests:
```
error: TypeError: Object.keys called on non-object
  at Function.keys (native)
  at ServerResponse.res.end (/Users/mdarveau/perso/workspace/maligue/node_modules/express-winston/index.js:231:51)
  at ServerResponse.res.send (/Users/mdarveau/perso/workspace/maligue/node_modules/sails/node_modules/express/lib/response.js:153:8)
  at ServerResponse.res.json (/Users/mdarveau/perso/workspace/maligue/node_modules/sails/node_modules/express/lib/response.js:195:15)
```

Note that this only triggers if you have something in `bodyBlacklist` and nothing in `bodyWhitelist`.