### PR TITLE
Allow filtering of the response body

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,6 +211,8 @@ function logger(options) {
               requestWhitelist = requestWhitelist.concat(req._routeWhitelists.req || []);
               responseWhitelist = responseWhitelist.concat(req._routeWhitelists.res || []);
 
+              meta.res = res;
+
               if (_.contains(responseWhitelist, 'body')) {
                 if (chunk) {
                   var isJson = (res._headers && res._headers['content-type']

--- a/index.js
+++ b/index.js
@@ -211,9 +211,6 @@ function logger(options) {
               requestWhitelist = requestWhitelist.concat(req._routeWhitelists.req || []);
               responseWhitelist = responseWhitelist.concat(req._routeWhitelists.res || []);
 
-              meta.req = filterObject(req, requestWhitelist, options.requestFilter);
-              meta.res = filterObject(res, responseWhitelist, options.responseFilter);
-
               if (_.contains(responseWhitelist, 'body')) {
                 if (chunk) {
                   var isJson = (res._headers && res._headers['content-type']
@@ -222,6 +219,9 @@ function logger(options) {
                   meta.res.body =  isJson ? JSON.parse(chunk) : chunk.toString();
                 }
               }
+
+              meta.req = filterObject(req, requestWhitelist, options.requestFilter);
+              meta.res = filterObject(res, responseWhitelist, options.responseFilter);
 
               bodyWhitelist = req._routeWhitelists.body || [];
               blacklist = _.union(bodyBlacklist, (req._routeBlacklists.body || []));


### PR DESCRIPTION
By simply moving the filtering of meta.res after the meta.res.body is set, we allow for custom filtering of the response body.  This is important for certain applications (e.g. we wish to truncate certain params from the response body in a custom manner)