### PR TITLE
call `ignoreRoute` with settled response object and finer grain filtering

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,7 +180,6 @@ function logger(options) {
         // Manage to get information from the response too, just like Connect.logger does:
         var end = res.end;
         res.end = function(chunk, encoding) {
-            if (options.ignoreRoute(req, res)) { return };
             res.responseTime = (new Date) - req._startTime;
 
             res.end = end;
@@ -250,7 +249,7 @@ function logger(options) {
               var msg = template({req: req, res: res});
             }
             // This is fire and forget, we don't want logging to hold up the request so don't wait for the callback
-            if (!options.skip(req, res)) {
+            if (!options.skip(req, res) && !options.ignoreRoute(req, res)) {
               options.winstonInstance.log(options.level, msg, meta);
             }
         };

--- a/index.js
+++ b/index.js
@@ -23,9 +23,9 @@ var util = require('util');
 var chalk = require('chalk');
 
 //Allow this file to get an exclusive copy of underscore so it can change the template settings without affecting others
-delete require.cache[require.resolve('underscore')];
-var _ = require('underscore');
-delete require.cache[require.resolve('underscore')];
+delete require.cache[require.resolve('lodash')];
+var _ = require('lodash');
+delete require.cache[require.resolve('lodash')];
 
 /**
  * A default list of properties in the request object that are allowed to be logged.
@@ -70,7 +70,7 @@ var ignoredRoutes = [];
  * @return {*}
  */
 var defaultRequestFilter = function (req, propName) {
-    return req[propName];
+    return _.result(req, propName);
 };
 
 /**
@@ -80,7 +80,7 @@ var defaultRequestFilter = function (req, propName) {
  * @return {*}
  */
 var defaultResponseFilter = function (res, propName) {
-    return res[propName];
+    return _.result(res, propName);
 };
 
 /**
@@ -92,7 +92,6 @@ var defaultSkip = function() {
 };
 
 function filterObject(originalObj, whiteList, initialFilter) {
-
     var obj = {};
     var fieldsSet = false;
 
@@ -100,12 +99,12 @@ function filterObject(originalObj, whiteList, initialFilter) {
         var value = initialFilter(originalObj, propName);
 
         if(typeof (value) !== 'undefined') {
-            obj[propName] = value;
+            _.set(obj, propName, value);
             fieldsSet = true;
         };
     });
 
-    return fieldsSet?obj:undefined;
+    return fieldsSet ? obj : undefined;
 }
 
 //

--- a/index.js
+++ b/index.js
@@ -164,7 +164,6 @@ function logger(options) {
     return function (req, res, next) {
         var currentUrl = req.originalUrl || req.url;
         if (currentUrl && _.contains(ignoredRoutes, currentUrl)) return next();
-        if (options.ignoreRoute(req, res)) return next();
 
         req._startTime = (new Date);
 
@@ -181,6 +180,7 @@ function logger(options) {
         // Manage to get information from the response too, just like Connect.logger does:
         var end = res.end;
         res.end = function(chunk, encoding) {
+            if (options.ignoreRoute(req, res)) { return };
             res.responseTime = (new Date) - req._startTime;
 
             res.end = end;
@@ -236,7 +236,7 @@ function logger(options) {
                     filteredBody = filterObject(req.body, bodyWhitelist, options.requestFilter);
                   }
               }
-              
+
               if (filteredBody) meta.req.body = filteredBody;
 
               meta.responseTime = res.responseTime;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "chalk": "~0.4.0",
-    "underscore": "~1.5.2",
+    "lodash": "~3.10.1",
     "winston": "~0.9.0"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 var should = require('should');
 var util = require('util');
-var _ = require('underscore');
+var _ = require('lodash');
 
 var mocks = require('node-mocks-http');
 var winston = require('winston');
@@ -588,7 +588,7 @@ describe('expressWinston', function () {
           });
         });
       });
-      
+
       describe('log.skip', function () {
         var result;
 


### PR DESCRIPTION
Building `ignoreRoute` rules around the `res.statusCode` we're not previously possible.