### PR TITLE
Add raw error info to error log meta.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -110,7 +110,8 @@ The logger needs to be added AFTER the express router(`app.router)`) and BEFORE 
     msg: String // customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}", "HTTP {{req.method}} {{req.url}}".
     baseMeta: Object, // default meta data to be added to log, this will be merged with the error data.
     metaField: String, // if defined, the meta data will be added in this field instead of the meta root object.
-    requestFilter: function (req, propName) { return req[propName]; } // A function to filter/return request values, defaults to returning all values allowed by whitelist. If the function returns undefined, the key/value will not be included in the meta.
+    requestFilter: function (req, propName) { return req[propName]; }, // A function to filter/return request values, defaults to returning all values allowed by whitelist. If the function returns undefined, the key/value will not be included in the meta.
+    errorTransform: function (err) { return err; } // A function to customize the error object exposed in the log
 ```
 
 To use winston's existing transports, set `transports` to the values (as in key-value) of the `winston.default.transports` object. This may be done, for example, by using underscorejs: `transports: _.values(winston.default.transports)`.


### PR DESCRIPTION
Fixes #95.

Useful for errors that have more information than is covered by the message text and stack trace.

Basically, all error logs will have an `error` property containing the raw error object (without the `stack` property, since that's already on the top level of the log). An `errorTransform` can be passed to the error logger options to customize the object put on to the `error` property (e.g., for removing properties that should not be exposed in the logs).