### PR TITLE
Refactored tests!

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,11 +52,12 @@
     "winston": "~1.0.0"
   },
   "devDependencies": {
-    "blanket": "~1.1.6",
-    "mocha": "~2.1.0",
-    "node-mocks-http": "~1.2.3",
-    "should": "~4.6.0",
-    "travis-cov": "~0.2.5"
+    "blanket": "^1.2.2",
+    "mocha": "^2.4.5",
+    "node-mocks-http": "^1.5.1",
+    "promise": "^7.1.1",
+    "should": "^8.2.2",
+    "travis-cov": "^0.2.5"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
(Hopefully) fixes #60.

Simplify the setup code used to create mock requests. Remove all shared state across tests. Convert mock requests to return promises for easy asynchronous testing. There should be no need now to use `before` or `beforeEach` blocks...

...which makes this possible: Moved `describe` and `it` blocks around so that it should be clearer 1) what tests go where, and 2) what is being tested.

I think there are still some holes in the test suite, but I think this new setup should make it easier to find and fix them.

For the sake of reviewers (@bithavoc and @floatingLomas), I thought it would be nicer to have the commits separated. I'll squash before merge/whenever if someone wants it squashed sooner.