### PR TITLE
Add per-instance equivalents of all global white/blacklists

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,6 +80,12 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
     skip: function(req, res) { return false; } // function to determine if logging is skipped, defaults to false.
     requestFilter: function (req, propName) { return req[propName]; } // A function to filter/return request values, defaults to returning all values allowed by whitelist. If the function returns undefined, the key/value will not be included in the meta.
     responseFilter: function (res, propName) { return res[propName]; } // A function to filter/return response values, defaults to returning all values allowed by whitelist. If the function returns undefined, the key/value will not be included in the meta.
+    requestWhitelist: [String] // Array of request properties to log. Overrides global requestWhitelist for this instance
+    responseWhitelist: [String] // Array of response properties to log. Overrides global responseWhitelist for this instance
+    bodyWhitelist: [String] // Array of body properties to log. Overrides global bodyWhitelist for this instance
+    bodyBlacklist: [String] // Array of body properties to omit from logs. Overrides global bodyBlacklist for this instance
+    ignoredRoutes: [String] // Array of paths to ignore/skip logging. Overrides global ignoredRoutes for this instance
+
 ```
 
 ### Error Logging
@@ -111,6 +117,7 @@ The logger needs to be added AFTER the express router(`app.router)`) and BEFORE 
     baseMeta: Object, // default meta data to be added to log, this will be merged with the error data.
     metaField: String, // if defined, the meta data will be added in this field instead of the meta root object.
     requestFilter: function (req, propName) { return req[propName]; } // A function to filter/return request values, defaults to returning all values allowed by whitelist. If the function returns undefined, the key/value will not be included in the meta.
+    requestWhitelist: [String] // Array of request properties to log. Overrides global requestWhitelist for this instance
 ```
 
 To use winston's existing transports, set `transports` to the values (as in key-value) of the `winston.default.transports` object. This may be done, for example, by using underscorejs: `transports: _.values(winston.default.transports)`.

--- a/test/test.js
+++ b/test/test.js
@@ -196,6 +196,30 @@ describe('express-winston', function () {
         });
       });
     });
+
+    describe('requestWhitelist option', function () {
+      it('should default to global requestWhitelist', function () {
+        var options = {
+          req: {foo: "bar"}
+        };
+        return errorLoggerTestHelper(options).then(function (result) {
+          result.log.meta.req.should.not.have.property('foo');
+        });
+      });
+
+      it('should use specified requestWhitelist', function () {
+        var options = {
+          req: {foo: "bar"},
+          loggerOptions: {
+            requestWhitelist: ['foo']
+          }
+        };
+        return errorLoggerTestHelper(options).then(function (result) {
+          result.log.meta.req.should.have.property('foo');
+          result.log.meta.req.should.not.have.property('method');
+        });
+      });
+    });
   });
 
   describe('.logger()', function () {
@@ -600,6 +624,77 @@ describe('express-winston', function () {
           return loggerTestHelper(testHelperOptions).then(function (result) {
             result.log.level.should.equal('verbose');
           });
+        });
+      });
+    });
+
+    describe('requestWhitelist option', function () {
+      it('should default to global requestWhitelist', function () {
+        var options = {
+          req: {foo: "bar"}
+        };
+        return loggerTestHelper(options).then(function (result) {
+          result.log.meta.req.should.not.have.property('foo');
+        });
+      });
+
+      it('should use specified requestWhitelist', function () {
+        var options = {
+          req: {foo: "bar"},
+          loggerOptions: {
+            requestWhitelist: ['foo']
+          }
+        };
+        return loggerTestHelper(options).then(function (result) {
+          result.log.meta.req.should.have.property('foo');
+          result.log.meta.req.should.not.have.property('method');
+        });
+      });
+    });
+
+    describe('responseWhitelist option', function () {
+      it('should default to global responseWhitelist', function () {
+        var options = {
+          res: {foo: "bar"}
+        };
+        return loggerTestHelper(options).then(function (result) {
+          result.log.meta.res.should.not.have.property('foo');
+        });
+      });
+
+      it('should use specified responseWhitelist', function () {
+        var options = {
+          res: {foo: "bar"},
+          loggerOptions: {
+            responseWhitelist: ['foo']
+          }
+        };
+        return loggerTestHelper(options).then(function (result) {
+          result.log.meta.res.should.have.property('foo');
+          result.log.meta.res.should.not.have.property('method');
+        });
+      });
+    });
+
+    describe('ignoredRoutes option', function () {
+      it('should default to global ignoredRoutes', function () {
+        var options = {
+          req: {url: "/ignored"}
+        };
+        return loggerTestHelper(options).then(function (result) {
+          result.transportInvoked.should.eql(false);
+        });
+      });
+
+      it('should use specified ignoredRoutes', function () {
+        var options = {
+          req: {url: "/ignored-option"},
+          loggerOptions: {
+            ignoredRoutes: ['/ignored-option']
+          }
+        };
+        return loggerTestHelper(options).then(function (result) {
+          result.transportInvoked.should.eql(false);
         });
       });
     });


### PR DESCRIPTION
This PR adds support for passing any any of the whitelists/blacklists as options to `expressWinston.logger()` and `expressWinston.errorLogger()`.

It leaves the global arrays intact, but I've prefixed the variable names with "global" to make things less ambiguous / avoid variable naming clashes in the code where they're used.

New options are:

```javascript
expressWinston.errorLogger({
    requestWhitelist: ['foo', 'bar']
});

expressWinston.logger({
    ignoredRoutes: ['/foo', '/bar'],
    requestWhitelist: ['foo', 'bar'],
    responseWhitelist: ['foo', 'bar'],
    bodyWhitelist: [...],
    bodyBlacklist: [...]
});
```

At our (fairly large) company we're working on common logger that anyone can/should use in their node apps, and we'd like to base it on express-winston. But, theoretically one of those people may use express-winston as well, and could silently break our common logger by modifying these whitelists globally, which makes it a no-go for us. The changes in the PR would fix this for us.

What do you think? Thanks!
—Noah



