### PR TITLE
underscore -> lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,7 @@ var winston = require('winston');
 var util = require('util');
 var chalk = require('chalk');
 
-//Allow this file to get an exclusive copy of underscore so it can change the template settings without affecting others
-delete require.cache[require.resolve('underscore')];
-var _ = require('underscore');
-delete require.cache[require.resolve('underscore')];
+var _ = require('lodash');
 
 /**
  * A default list of properties in the request object that are allowed to be logged.
@@ -126,7 +123,7 @@ exports.errorLogger = function errorLogger(options) {
     options.metaField = options.metaField || null;
 
     // Using mustache style templating
-    var template = _.template(options.msg, null, {
+    var template = _.template(options.msg, {
       interpolate: /\{\{(.+?)\}\}/g
     });
 
@@ -181,13 +178,13 @@ exports.logger = function logger(options) {
     options.skip = options.skip || exports.defaultSkip;
 
     // Using mustache style templating
-    var template = _.template(options.msg, null, {
+    var template = _.template(options.msg, {
       interpolate: /\{\{(.+?)\}\}/g
     });
 
     return function (req, res, next) {
         var currentUrl = req.originalUrl || req.url;
-        if (currentUrl && _.contains(options.ignoredRoutes, currentUrl)) return next();
+        if (currentUrl && _.includes(options.ignoredRoutes, currentUrl)) return next();
         if (options.ignoreRoute(req, res)) return next();
 
         req._startTime = (new Date);
@@ -237,7 +234,7 @@ exports.logger = function logger(options) {
 
               logData.res = res;
 
-              if (_.contains(responseWhitelist, 'body')) {
+              if (_.includes(responseWhitelist, 'body')) {
                 if (chunk) {
                   var isJson = (res._headers && res._headers['content-type']
                     && res._headers['content-type'].indexOf('json') >= 0);
@@ -256,7 +253,7 @@ exports.logger = function logger(options) {
 
               if ( req.body !== undefined ) {
                   if (blacklist.length > 0 && bodyWhitelist.length === 0) {
-                    var whitelist = _.difference(_.keys(req.body), blacklist);
+                    var whitelist = _.difference(Object.keys(req.body), blacklist);
                     filteredBody = filterObject(req.body, whitelist, options.requestFilter);
                   } else {
                     filteredBody = filterObject(req.body, bodyWhitelist, options.requestFilter);

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "chalk": "~0.4.0",
-    "underscore": "~1.5.2",
+    "lodash": "~4.11.1",
     "winston": "~1.0.0"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ var util = require('util');
 var mocks = require('node-mocks-http');
 var Promise = require('promise/lib/es6-extensions');
 var should = require('should');
-var _ = require('underscore');
+var _ = require('lodash');
 var winston = require('winston');
 
 var expressWinston = require('../index.js');


### PR DESCRIPTION
Fixes #88.

Changes:
- `_.template`: minor API change
- `_.contains`: called `includes` in lodash 4
- `_.keys`: underscore simply used `Object.keys` if available, so cut out the middleman

Why lodash instead of underscore?
- lodash is more popular (see npm stats)
- lodash follows semantic versioning
- lodash has more functions (e.g., `_.get` which could come in handy for #62 and #66)