### PR TITLE
2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+## 2.0.0
+#### Breaking changes
+* Make winston a peer dependency. `npm install --save winston` if you haven't already.
+* `expressFormat` has no color by default. Add `colorize: true` to express-winston
+  options to enable the previous colorized output. ([#86](https://github.com/bithavoc/express-winston/issues/86))
+* Drop support for inherited properties on the object provided to the `baseMeta` option. This is unlikely to actually break anyone's real-world setup.
+
+## 1.4.2
+* Upgrade winston to 1.1 ([#114](https://github.com/bithavoc/express-winston/issues/114))
+
+## 1.4.1
+* Don't throw exception on invalid JSON in response body ([#112](https://github.com/bithavoc/express-winston/issues/112))
+
+## 1.4.0
+* Allow custom log level for error logger ([#111](https://github.com/bithavoc/express-winston/pull/111))
+
+## 1.3.1
+* underscore -> lodash ([#88](https://github.com/bithavoc/express-winston/issues/88))
+
+## 1.3.0
+* Allow custom status levels ([#102](https://github.com/bithavoc/express-winston/pull/102))
+* Add per-instance equivalents of all global white/blacklists ([#105](https://github.com/bithavoc/express-winston/pull/105))
+* Allow user to override module-level whitelists and functions without having to worry about using the right object reference ([#92](https://github.com/bithavoc/express-winston/issues/92))
+
+## 1.2.0
+* Add `baseMeta` and `metaField` options ([#91](https://github.com/bithavoc/express-winston/pull/91))
+* Document `requestFilter` and `responseFilter` options
+* Drop support for node 0.6 and 0.8

--- a/Readme.md
+++ b/Readme.md
@@ -55,8 +55,8 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
       ],
       meta: true, // optional: control whether you want to log the meta data about the request (default to true)
       msg: "HTTP {{req.method}} {{req.url}}", // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
-      expressFormat: true, // Use the default Express/morgan request formatting, with the same colors. Enabling this will override any msg and colorStatus if true. Will only output colors on transports with colorize set to true
-      colorStatus: true, // Color the status code, using the Express/morgan color palette (default green, 3XX cyan, 4XX yellow, 5XX red). Will not be recognized if expressFormat is true
+      expressFormat: true, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors with colorize set to true
+      colorize: true, // Color the text and status code, using the Express/morgan color palette (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
       ignoreRoute: function (req, res) { return false; } // optional: allows to skip some log messages based on request and/or response
     }));
 
@@ -70,8 +70,8 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
     winstonInstance: <WinstonLogger>, // a winston logger instance. If this is provided the transports option is ignored.
     level: String, // log level to use, the default is "info".
     msg: String // customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}", "HTTP {{req.method}} {{req.url}}".
-    expressFormat: Boolean, // Use the default Express/morgan request formatting, with the same colors. Enabling this will override any msg and colorStatus if true. Will only output colors on transports with colorize set to true
-    colorStatus: Boolean, // Color the status code, using the Express/morgan color palette (default green, 3XX cyan, 4XX yellow, 5XX red). Will not be recognized if expressFormat is true
+    expressFormat: Boolean, // Use the default Express/morgan request formatting, with the same colors. Enabling this will override any msg if true. Will only output colors on transports with colorize set to true
+    colorize: Boolean, // Color the text and status code, using the Express/morgan color palette (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
     meta: Boolean, // control whether you want to log the meta data about the request (default to true).
     baseMeta: Object, // default meta data to be added to log, this will be merged with the meta data.
     metaField: String, // if defined, the meta data will be added in this field instead of the meta root object.

--- a/Readme.md
+++ b/Readme.md
@@ -5,13 +5,9 @@
 
 ## Installation
 
-Newcomers should start with the latest branch which makes use of winston 1.x.x and supports node >= 0.10:
+    npm install winston express-winston
 
-    npm install express-winston
-
-If you're already using express-winston, and want to stick with the stable version based on winston 0.9.x, you should instead do:
-
-    npm install express-winston@0.x.x --save
+(supports node >= 0.10)
 
 ## Usage
 
@@ -25,8 +21,8 @@ In `package.json`:
 {
   "dependencies": {
     "...": "...",
-    "winston": "0.6.x",
-    "express-winston": "0.2.x",
+    "winston": "^2.0.0",
+    "express-winston": "^2.0.0",
     "...": "..."
   }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -70,7 +70,7 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
     winstonInstance: <WinstonLogger>, // a winston logger instance. If this is provided the transports option is ignored.
     level: String, // log level to use, the default is "info".
     msg: String // customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}", "HTTP {{req.method}} {{req.url}}".
-    expressFormat: Boolean, // Use the default Express/morgan request formatting, with the same colors. Enabling this will override any msg if true. Will only output colors on transports with colorize set to true
+    expressFormat: Boolean, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors when colorize set to true
     colorize: Boolean, // Color the text and status code, using the Express/morgan color palette (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
     meta: Boolean, // control whether you want to log the meta data about the request (default to true).
     baseMeta: Object, // default meta data to be added to log, this will be merged with the meta data.

--- a/index.js
+++ b/index.js
@@ -174,16 +174,11 @@ exports.logger = function logger(options) {
     options.baseMeta = options.baseMeta || {};
     options.metaField = options.metaField || null;
     options.colorize = options.colorize || false;
-    options.statusColor = options.statusColor || false;
     options.expressFormat = options.expressFormat || false;
     options.ignoreRoute = options.ignoreRoute || function () { return false; };
     options.skip = options.skip || exports.defaultSkip;
 
     return function (req, res, next) {
-        //to add colors on req / res values
-        var colored_req = {};
-        var colored_res = {};
-
         var currentUrl = req.originalUrl || req.url;
         if (currentUrl && _.includes(options.ignoredRoutes, currentUrl)) return next();
         if (options.ignoreRoute(req, res)) return next();
@@ -215,15 +210,6 @@ exports.logger = function logger(options) {
               if (res.statusCode >= 400) { options.level = options.statusLevels.warn || "warn"; }
               if (res.statusCode >= 500) { options.level = options.statusLevels.error || "error"; }
             };
-
-            if (options.colorize || options.statusColor) {
-              // Palette from https://github.com/expressjs/morgan/blob/master/index.js#L205
-              var statusColor = 'green';
-              if (res.statusCode >= 500) statusColor = 'red';
-              else if (res.statusCode >= 400) statusColor = 'yellow';
-              else if (res.statusCode >= 300) statusColor = 'cyan';
-              colored_res.statusCode = chalk[statusColor](res.statusCode);
-            }
 
             var meta = {};
 
@@ -275,19 +261,26 @@ exports.logger = function logger(options) {
 
             meta = _.extend(meta, options.baseMeta);
 
+            var expressMsgFormat = "{{req.method}} {{req.url}} {{res.statusCode}} {{res.responseTime}}ms";
+            if (options.colorize) {
+              // Palette from https://github.com/expressjs/morgan/blob/master/index.js#L205
+              var statusColor = 'green';
+              if (res.statusCode >= 500) statusColor = 'red';
+              else if (res.statusCode >= 400) statusColor = 'yellow';
+              else if (res.statusCode >= 300) statusColor = 'cyan';
 
-            var msgFormat = !options.expressFormat ? options.msg : "{{req.method}} {{req.url}} {{res.statusCode}} {{res.responseTime}}ms";
+              expressMsgFormat = chalk.grey("{{req.method}} {{req.url}}") +
+                " " + chalk[statusColor]("{{res.statusCode}}") + " " +
+                chalk.grey("{{res.responseTime}}ms");
+            }
+            var msgFormat = !options.expressFormat ? options.msg : expressMsgFormat;
 
             // Using mustache style templating
             var template = _.template(msgFormat, {
               interpolate: /\{\{(.+?)\}\}/g
             });
 
-            var msg = template({req: _.extend({}, req, colored_req), res: _.extend({}, res, colored_res)});
-
-            if(options.colorize) {
-              msg = chalk.grey(msg);
-            }
+            var msg = template({req: req, res: res});
 
             // This is fire and forget, we don't want logging to hold up the request so don't wait for the callback
             if (!options.skip(req, res)) {

--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ exports.errorLogger = function errorLogger(options) {
             exceptionMeta = newMeta;
         }
 
-        exceptionMeta = _.extend(exceptionMeta, options.baseMeta);
+        exceptionMeta = _.assign(exceptionMeta, options.baseMeta);
 
         // This is fire and forget, we don't want logging to hold up the request so don't wait for the callback
         options.winstonInstance.log(options.level, template({err: err, req: req, res: res}), exceptionMeta);
@@ -256,10 +256,10 @@ exports.logger = function logger(options) {
                   newMeta[options.metaField] = logData;
                   logData = newMeta;
               }
-              meta = _.extend(meta, logData);
+              meta = _.assign(meta, logData);
             }
 
-            meta = _.extend(meta, options.baseMeta);
+            meta = _.assign(meta, options.baseMeta);
 
             var expressMsgFormat = "{{req.method}} {{req.url}} {{res.statusCode}} {{res.responseTime}}ms";
             if (options.colorize) {

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
   },
   "dependencies": {
     "chalk": "~0.4.0",
-    "lodash": "~4.11.1",
-    "winston": "~1.1.0"
+    "lodash": "~4.11.1"
   },
   "devDependencies": {
     "blanket": "^1.2.2",
@@ -57,7 +56,11 @@
     "node-mocks-http": "^1.5.1",
     "promise": "^7.1.1",
     "should": "^8.2.2",
-    "travis-cov": "^0.2.5"
+    "travis-cov": "^0.2.5",
+    "winston": ">=1.x"
+  },
+  "peerDependencies": {
+    "winston": ">=1.x"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/test/test.js
+++ b/test/test.js
@@ -586,6 +586,7 @@ describe('express-winston', function () {
       it('should match the Express format when logging', function () {
         var testHelperOptions = {
           loggerOptions: {
+            colorize: true,
             expressFormat: true
           },
           req: {
@@ -596,6 +597,40 @@ describe('express-winston', function () {
           var resultMsg = result.log.msg;
           resultMsg.should.startWith('\u001b[90mGET /all-the-things\u001b[39m \u001b[32m200\u001b[39m \u001b[90m');
           resultMsg.should.endWith('ms\u001b[39m');
+        });
+      });
+
+      it('should not emit colors when colorize option is false', function() {
+        var testHelperOptions = {
+          loggerOptions: {
+            colorize: false,
+            expressFormat: true
+          },
+          req: {
+            url: '/all-the-things'
+          }
+        };
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          var resultMsg = result.log.msg;
+          resultMsg.should.startWith('GET /all-the-things 200 ');
+          resultMsg.should.endWith('ms');
+        });
+      });
+
+      it('should not emit colors when colorize option is not present', function() {
+        var testHelperOptions = {
+          loggerOptions: {
+            colorize: false,
+            expressFormat: true
+          },
+          req: {
+            url: '/all-the-things'
+          }
+        };
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          var resultMsg = result.log.msg;
+          resultMsg.should.startWith('GET /all-the-things 200 ');
+          resultMsg.should.endWith('ms');
         });
       });
     });


### PR DESCRIPTION
There are 3 changes (all breaking):
* Make winston a peer dependency, ensuring that the user and module are always using the same version of winston. As a side benefit, users get a newer winston module on their own timeline.
* Fix #86. Default output of expressFormat has no color. Add `colorize: true` to _express-winston_  options to enable the previous colorized output. The `colorize` option on express-winston is not related to the option of the same name on some winston transports. (Thank you to @brunolemos for pointing the way forward in #109).
* Drop support for inherited properties on the object provided to the `baseMeta` option. Users probably didn't rely on this functionality, and it could've actually been surprising in a bad way. Also allows us to use ES2015 `Object.assign` in the (very bright) future.

Commits are left un-squashed for the moment to see the thinking process. I'll squash to 3 commits before merge.

Feedback welcome!