### PR TITLE
Add dynamic meta data support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,6 +81,7 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
     bodyWhitelist: [String] // Array of body properties to log. Overrides global bodyWhitelist for this instance
     bodyBlacklist: [String] // Array of body properties to omit from logs. Overrides global bodyBlacklist for this instance
     ignoredRoutes: [String] // Array of paths to ignore/skip logging. Overrides global ignoredRoutes for this instance
+    dynamicMeta: function(req, res) { return [Object]; } // Extract additional meta data from request or response (typically req.user data if using passport). meta must be true for this function to be activated
 
 ```
 
@@ -379,6 +380,25 @@ If you set statusLevels to true express-winston will log sub 400 responses at in
     "warn": "debug",
     "error": "info"
   }
+```
+
+
+## Dynamic meta data from request or response
+
+If you set dynamicMeta function you can extract additional meta data fields from request or response objects.
+The function can be used to either select relevant elements in request or response body without logging them as a whole
+or to extract runtime data like the user making the request. The example below logs the user name and role as assigned
+by the passport authentication middleware.
+
+```js
+   meta: true,
+   dynamicMeta: function(req, res) {
+     return {
+       user: req.user ? req.user.username : null,
+       role: req.user ? req.user.role : null,
+       ...
+   }
+}
 ```
 
 ## Tests

--- a/index.js
+++ b/index.js
@@ -177,6 +177,7 @@ exports.logger = function logger(options) {
     options.expressFormat = options.expressFormat || false;
     options.ignoreRoute = options.ignoreRoute || function () { return false; };
     options.skip = options.skip || exports.defaultSkip;
+    options.dynamicMeta = options.dynamicMeta || function(req, res) { return null; };
 
     return function (req, res, next) {
         var currentUrl = req.originalUrl || req.url;
@@ -251,8 +252,13 @@ exports.logger = function logger(options) {
 
               logData.responseTime = res.responseTime;
 
+              if(options.dynamicMeta) {
+                  var dynamicMeta = options.dynamicMeta(req, res);
+                  logData = _.assign(logData, dynamicMeta);
+              }
+
               if (options.metaField) {
-                  var newMeta = {}
+                  var newMeta = {};
                   newMeta[options.metaField] = logData;
                   logData = newMeta;
               }
@@ -317,5 +323,9 @@ function ensureValidOptions(options) {
 function ensureValidLoggerOptions(options) {
     if (options.ignoreRoute && !_.isFunction(options.ignoreRoute)) {
         throw new Error("`ignoreRoute` express-winston option should be a function");
+    }
+
+    if (options.dynamicMeta && !_.isFunction(options.dynamicMeta)) {
+        throw new Error("`dynamicMeta` express-winston option should be a function");
     }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -932,6 +932,69 @@ describe('express-winston', function () {
         });
       });
     });
+
+    describe('dynamicMeta option', function () {
+      var testHelperOptions = {
+        req: {
+          body: {
+            age: 42,
+            potato: 'Russet'
+          },
+          user: {
+            username: "john@doe.com",
+            role: "operator"
+          }
+        },
+        res: {
+          custom: 'custom response runtime field'
+        },
+        loggerOptions: {
+          meta: true,
+          dynamicMeta: function(req, res) {
+            return {
+              user: req.user.username,
+              role: req.user.role,
+              custom: res.custom
+            }
+          }
+        }
+      };
+
+      it('should contain dynamic meta data if meta and dynamicMeta activated', function () {
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          result.log.meta.req.should.be.ok();
+          result.log.meta.user.should.equal('john@doe.com');
+          result.log.meta.role.should.equal('operator');
+          result.log.meta.custom.should.equal('custom response runtime field');
+        });
+      });
+
+      it('should work with metaField option', function () {
+        testHelperOptions.loggerOptions.metaField = 'metaField';
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          console.log("*** result: " + JSON.stringify(result));
+          result.log.meta.metaField.req.should.be.ok();
+          result.log.meta.metaField.user.should.equal('john@doe.com');
+          result.log.meta.metaField.role.should.equal('operator');
+          result.log.meta.metaField.custom.should.equal('custom response runtime field');
+        });
+      });
+
+      it('should not contain dynamic meta data if dynamicMeta activated but meta false', function () {
+        testHelperOptions.loggerOptions.meta = false;
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          should.not.exist(result.log.meta.req);
+          should.not.exist(result.log.meta.user);
+          should.not.exist(result.log.meta.role);
+          should.not.exist(result.log.meta.custom);
+        });
+      });
+
+      it('should throw an error if dynamicMeta is not a function', function () {
+        var loggerFn = expressWinston.logger.bind(expressWinston, {dynamicMeta: 12});
+        loggerFn.should.throw();
+      });
+    });
   });
 
   describe('.requestWhitelist', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -972,7 +972,6 @@ describe('express-winston', function () {
       it('should work with metaField option', function () {
         testHelperOptions.loggerOptions.metaField = 'metaField';
         return loggerTestHelper(testHelperOptions).then(function (result) {
-          console.log("*** result: " + JSON.stringify(result));
           result.log.meta.metaField.req.should.be.ok();
           result.log.meta.metaField.user.should.equal('john@doe.com');
           result.log.meta.metaField.role.should.equal('operator');


### PR DESCRIPTION
The root requirement for this was to extract user data on express/passport apps using OAuth2 but I've tried to make it generic so one can log dynamic meta data from request or response to ease logs post processing.