### PR TITLE
Add support for colorize without expressFormat.

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,6 +180,8 @@ exports.logger = function logger(options) {
     options.dynamicMeta = options.dynamicMeta || function(req, res) { return null; };
 
     return function (req, res, next) {
+        var coloredRes = {};
+
         var currentUrl = req.originalUrl || req.url;
         if (currentUrl && _.includes(options.ignoredRoutes, currentUrl)) return next();
         if (options.ignoreRoute(req, res)) return next();
@@ -276,8 +278,9 @@ exports.logger = function logger(options) {
               else if (res.statusCode >= 300) statusColor = 'cyan';
 
               expressMsgFormat = chalk.grey("{{req.method}} {{req.url}}") +
-                " " + chalk[statusColor]("{{res.statusCode}}") + " " +
+                " {{res.statusCode}} " +
                 chalk.grey("{{res.responseTime}}ms");
+              coloredRes.statusCode = chalk[statusColor](res.statusCode);
             }
             var msgFormat = !options.expressFormat ? options.msg : expressMsgFormat;
 
@@ -286,7 +289,7 @@ exports.logger = function logger(options) {
               interpolate: /\{\{(.+?)\}\}/g
             });
 
-            var msg = template({req: req, res: res});
+            var msg = template({req: req, res: _.assign({}, res, coloredRes)});
 
             // This is fire and forget, we don't want logging to hold up the request so don't wait for the callback
             if (!options.skip(req, res)) {

--- a/test/test.js
+++ b/test/test.js
@@ -635,6 +635,81 @@ describe('express-winston', function () {
       });
     });
 
+    describe('colorize option', function () {
+      it('should make status code text green if < 300', function () {
+        var testHelperOptions = {
+          loggerOptions: {
+            colorize: true,
+            msg: '{{res.statusCode}} {{req.method}} {{req.url}}'
+          },
+          req: {
+            url: '/all-the-things'
+          }
+        };
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          var resultMsg = result.log.msg;
+          resultMsg.should.eql('\u001b[32m200\u001b[39m GET /all-the-things');
+        });
+      });
+
+      it('should make status code text cyan if >= 300 and < 400', function () {
+        var testHelperOptions = {
+          loggerOptions: {
+            colorize: true,
+            msg: '{{res.statusCode}} {{req.method}} {{req.url}}'
+          },
+          req: {
+            url: '/all-the-things'
+          },
+          res: {
+            statusCode: 302
+          }
+        };
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          var resultMsg = result.log.msg;
+          resultMsg.should.eql('\u001b[36m302\u001b[39m GET /all-the-things');
+        });
+      });
+
+      it('should make status code text yellow if >= 400 and < 500', function () {
+        var testHelperOptions = {
+          loggerOptions: {
+            colorize: true,
+            msg: '{{res.statusCode}} {{req.method}} {{req.url}}'
+          },
+          req: {
+            url: '/all-the-things'
+          },
+          res: {
+            statusCode: 420
+          }
+        };
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          var resultMsg = result.log.msg;
+          resultMsg.should.eql('\u001b[33m420\u001b[39m GET /all-the-things');
+        });
+      });
+
+      it('should make status code text red if >= 500', function () {
+        var testHelperOptions = {
+          loggerOptions: {
+            colorize: true,
+            msg: '{{res.statusCode}} {{req.method}} {{req.url}}'
+          },
+          req: {
+            url: '/all-the-things'
+          },
+          res: {
+            statusCode: 500
+          }
+        };
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          var resultMsg = result.log.msg;
+          resultMsg.should.eql('\u001b[31m500\u001b[39m GET /all-the-things');
+        });
+      });
+    });
+
     describe('msg option', function () {
       it('should have a default log msg', function () {
         var testHelperOptions = {


### PR DESCRIPTION
Fixes #121.

Simply colorizes the status code (based on its value). The user can choose color for the rest of the message themselves if they so desire (using `chalk` + `msg` option).