### PR TITLE
Update node versions in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ node_js:
   - "0.10"
   - "0.11"
   - "0.12"
-  - "4.2"
-  - "5.3"
-  - "iojs"
+  - "4"
+  - "6"
+  - "7"
 
 script:
   - "test $TRAVIS_NODE_VERSION  = '0.6' || npm test"


### PR DESCRIPTION
* Remove iojs and node 5. They're not officially supported anymore, and were pretty bleeding edge, so most of those users probably upgraded to newer node versions. Plus, they're pretty well-covered by versions getting tested above and below them (0.12 + 4 + 6).
* Add node 6 (LTS) and 7.

I'm putting this in a PR just so people can have it for reference.

I'm thinking we'll drop 0.10 and 0.12 support in the next major version, since those are both [pretty popular in production](https://semaphoreci.com/blog/2016/10/12/nodejs-versions-used-in-commercial-projects-2016-edition.html). Additionally, dropping support for those versions (and officially dropping iojs) will allow/encourage backwards-incompatible changes, such as moving to ES6.