### PR TITLE
Add dynamic meta to error logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,6 @@ function filterObject(originalObj, whiteList, initialFilter) {
 exports.errorLogger = function errorLogger(options) {
 
     ensureValidOptions(options);
-    ensureValidLoggerOptions(options);
 
     options.requestWhitelist = options.requestWhitelist || exports.requestWhitelist;
     options.requestFilter = options.requestFilter || exports.defaultRequestFilter;
@@ -340,14 +339,14 @@ function ensureValidOptions(options) {
     if(!options) throw new Error("options are required by express-winston middleware");
     if(!((options.transports && (options.transports.length > 0)) || options.winstonInstance))
         throw new Error("transports or a winstonInstance are required by express-winston middleware");
+
+    if (options.dynamicMeta && !_.isFunction(options.dynamicMeta)) {
+        throw new Error("`dynamicMeta` express-winston option should be a function");
+    }
 }
 
 function ensureValidLoggerOptions(options) {
     if (options.ignoreRoute && !_.isFunction(options.ignoreRoute)) {
         throw new Error("`ignoreRoute` express-winston option should be a function");
-    }
-
-    if (options.dynamicMeta && !_.isFunction(options.dynamicMeta)) {
-        throw new Error("`dynamicMeta` express-winston option should be a function");
     }
 }

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ exports.errorLogger = function errorLogger(options) {
     options.baseMeta = options.baseMeta || {};
     options.metaField = options.metaField || null;
     options.level = options.level || 'error';
-    options.dynamicMeta = options.dynamicMeta || function(err, req, res) { return null; };
+    options.dynamicMeta = options.dynamicMeta || function(req, res, err) { return null; };  
 
     // Using mustache style templating
     var template = _.template(options.msg, {
@@ -137,7 +137,7 @@ exports.errorLogger = function errorLogger(options) {
         exceptionMeta.req = filterObject(req, options.requestWhitelist, options.requestFilter);
         
         if(options.dynamicMeta) {
-            var dynamicMeta = options.dynamicMeta(err, req, res);
+            var dynamicMeta = options.dynamicMeta(req, res, err);
             exceptionMeta = _.assign(exceptionMeta, dynamicMeta);
         }
 


### PR DESCRIPTION
Add option to receive dynamic meta when using the `errorLogger` function. PR related to issue #95. 