### PR TITLE
Add dynamicMeta to errorLogger

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -116,6 +116,7 @@ The logger needs to be added AFTER the express router(`app.router)`) and BEFORE 
     requestFilter: function (req, propName) { return req[propName]; } // A function to filter/return request values, defaults to returning all values allowed by whitelist. If the function returns undefined, the key/value will not be included in the meta.
     requestWhitelist: [String] // Array of request properties to log. Overrides global requestWhitelist for this instance
     level: String // custom log level for errors (default is 'error')
+    dynamicMeta: function(req, res, err) { return [Object]; } // Extract additional meta data from request or response (typically req.user data if using passport). meta must be true for this function to be activated
 ```
 
 To use winston's existing transports, set `transports` to the values (as in key-value) of the `winston.default.transports` object. This may be done, for example, by using underscorejs: `transports: _.values(winston.default.transports)`.

--- a/index.js
+++ b/index.js
@@ -339,14 +339,14 @@ function ensureValidOptions(options) {
     if(!options) throw new Error("options are required by express-winston middleware");
     if(!((options.transports && (options.transports.length > 0)) || options.winstonInstance))
         throw new Error("transports or a winstonInstance are required by express-winston middleware");
+
+    if (options.dynamicMeta && !_.isFunction(options.dynamicMeta)) {
+        throw new Error("`dynamicMeta` express-winston option should be a function");
+    }
 }
 
 function ensureValidLoggerOptions(options) {
     if (options.ignoreRoute && !_.isFunction(options.ignoreRoute)) {
         throw new Error("`ignoreRoute` express-winston option should be a function");
-    }
-
-    if (options.dynamicMeta && !_.isFunction(options.dynamicMeta)) {
-        throw new Error("`dynamicMeta` express-winston option should be a function");
     }
 }

--- a/index.js
+++ b/index.js
@@ -122,6 +122,7 @@ exports.errorLogger = function errorLogger(options) {
     options.baseMeta = options.baseMeta || {};
     options.metaField = options.metaField || null;
     options.level = options.level || 'error';
+    options.dynamicMeta = options.dynamicMeta || function(req, res, err) { return null; };  
 
     // Using mustache style templating
     var template = _.template(options.msg, {
@@ -133,6 +134,11 @@ exports.errorLogger = function errorLogger(options) {
         // Let winston gather all the error data.
         var exceptionMeta = winston.exception.getAllInfo(err);
         exceptionMeta.req = filterObject(req, options.requestWhitelist, options.requestFilter);
+        
+        if(options.dynamicMeta) {
+            var dynamicMeta = options.dynamicMeta(req, res, err);
+            exceptionMeta = _.assign(exceptionMeta, dynamicMeta);
+        }
 
         if (options.metaField) {
             var newMeta = {};

--- a/test/test.js
+++ b/test/test.js
@@ -119,6 +119,7 @@ function errorLoggerTestHelper(providedOptions) {
 }
 
 describe('express-winston', function () {
+
   describe('.errorLogger()', function () {
     it('should be a function', function () {
       expressWinston.errorLogger.should.be.a.Function();
@@ -260,6 +261,68 @@ describe('express-winston', function () {
         });
       });
     });
+
+    describe('dynamicMeta option', function () {
+      var testHelperOptions = {
+        req: {
+          body: {
+            age: 42,
+            potato: 'Russet'
+          },
+          user: {
+            username: "john@doe.com",
+            role: "operator"
+          }
+        },
+        res: {
+          custom: 'custom response runtime field'
+        },
+        loggerOptions: {
+          meta: true,
+          dynamicMeta: function(req, res) {
+            return {
+              user: req.user.username,
+              role: req.user.role,
+              custom: res.custom
+            }
+          }
+        }
+      };
+
+      it('should contain dynamic meta data if meta and dynamicMeta activated', function () {
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          result.log.meta.req.should.be.ok();
+          result.log.meta.user.should.equal('john@doe.com');
+          result.log.meta.role.should.equal('operator');
+          result.log.meta.custom.should.equal('custom response runtime field');
+        });
+      });
+
+      it('should work with metaField option', function () {
+        testHelperOptions.loggerOptions.metaField = 'metaField';
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          result.log.meta.metaField.req.should.be.ok();
+          result.log.meta.metaField.user.should.equal('john@doe.com');
+          result.log.meta.metaField.role.should.equal('operator');
+          result.log.meta.metaField.custom.should.equal('custom response runtime field');
+        });
+      });
+
+      it('should not contain dynamic meta data if dynamicMeta activated but meta false', function () {
+        testHelperOptions.loggerOptions.meta = false;
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          should.not.exist(result.log.meta.req);
+          should.not.exist(result.log.meta.user);
+          should.not.exist(result.log.meta.role);
+          should.not.exist(result.log.meta.custom);
+        });
+      });
+
+      it('should throw an error if dynamicMeta is not a function', function () {
+        var loggerFn = expressWinston.logger.bind(expressWinston, {dynamicMeta: 12});
+        loggerFn.should.throw();
+      });
+    }); 
   });
 
   describe('.logger()', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -277,52 +277,57 @@ describe('express-winston', function () {
         res: {
           custom: 'custom response runtime field'
         },
+        originalError: new Error('FOO'),
         loggerOptions: {
           meta: true,
-          dynamicMeta: function(req, res) {
+          dynamicMeta: function(req, res, err) {
             return {
               user: req.user.username,
               role: req.user.role,
-              custom: res.custom
+              custom: res.custom,
+              errMessage: err.message
             }
           }
         }
       };
 
       it('should contain dynamic meta data if meta and dynamicMeta activated', function () {
-        return loggerTestHelper(testHelperOptions).then(function (result) {
+        return errorLoggerTestHelper(testHelperOptions).then(function (result) {
           result.log.meta.req.should.be.ok();
           result.log.meta.user.should.equal('john@doe.com');
           result.log.meta.role.should.equal('operator');
           result.log.meta.custom.should.equal('custom response runtime field');
+          result.log.meta.errMessage.should.equal('FOO');
         });
       });
 
       it('should work with metaField option', function () {
         testHelperOptions.loggerOptions.metaField = 'metaField';
-        return loggerTestHelper(testHelperOptions).then(function (result) {
+        return errorLoggerTestHelper(testHelperOptions).then(function (result) {
           result.log.meta.metaField.req.should.be.ok();
           result.log.meta.metaField.user.should.equal('john@doe.com');
           result.log.meta.metaField.role.should.equal('operator');
           result.log.meta.metaField.custom.should.equal('custom response runtime field');
+          result.log.meta.metaField.errMessage.should.equal('FOO');
         });
       });
 
       it('should not contain dynamic meta data if dynamicMeta activated but meta false', function () {
         testHelperOptions.loggerOptions.meta = false;
-        return loggerTestHelper(testHelperOptions).then(function (result) {
+        return errorLoggerTestHelper(testHelperOptions).then(function (result) {
           should.not.exist(result.log.meta.req);
           should.not.exist(result.log.meta.user);
           should.not.exist(result.log.meta.role);
           should.not.exist(result.log.meta.custom);
+          should.not.exist(result.log.meta.errMessage);
         });
       });
 
       it('should throw an error if dynamicMeta is not a function', function () {
-        var loggerFn = expressWinston.logger.bind(expressWinston, {dynamicMeta: 12});
+        var loggerFn = expressWinston.errorLogger.bind(expressWinston, {dynamicMeta: 12});
         loggerFn.should.throw();
       });
-    }); 
+    });
   });
 
   describe('.logger()', function () {


### PR DESCRIPTION
Add option to receive dynamic meta when using the errorLogger function. PR related to issue #95 
