### PR TITLE
Log original req.body object

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,6 +130,8 @@ exports.errorLogger = function errorLogger(options) {
     });
 
     return function (err, req, res, next) {
+        req.body = req._originalBody || req.body;
+        delete req._originalBody;
 
         // Let winston gather all the error data.
         var exceptionMeta = winston.exception.getAllInfo(err);
@@ -192,6 +194,8 @@ exports.logger = function logger(options) {
         if (currentUrl && _.includes(options.ignoredRoutes, currentUrl)) return next();
         if (options.ignoreRoute(req, res)) return next();
 
+        req._originalBody = _.cloneDeep(req.body);
+
         req._startTime = (new Date);
 
         req._routeWhitelists = {
@@ -208,6 +212,9 @@ exports.logger = function logger(options) {
         var end = res.end;
         res.end = function(chunk, encoding) {
             res.responseTime = (new Date) - req._startTime;
+
+            req.body = req._originalBody || req.body;
+            delete req._originalBody;
 
             res.end = end;
             res.end(chunk, encoding);

--- a/test/test.js
+++ b/test/test.js
@@ -565,6 +565,30 @@ describe('express-winston', function () {
       });
     });
 
+    it('should log original req.body even if the object is mutated', function () {
+      function next(req, res, next) {
+        req.body.value = req.body.value.replace(/-/g, ' ');
+
+        res.end();
+      }
+      var testHelperOptions = {
+        next: next,
+        req: {
+          body: {
+            foo: 'bar',
+            value: 'i-have-dashes',
+          },
+          url: '/hello'
+        },
+      };
+      return loggerTestHelper(testHelperOptions).then(function (result) {
+        result.log.meta.req.body.should.eql({
+          foo: 'bar',
+          value: 'i-have-dashes'
+        });
+      });
+    });
+
     describe('when middleware function is invoked on a route', function () {
       function next(req, res, next) {
         req._startTime = (new Date()) - 125;


### PR DESCRIPTION
I ran into an issue with mutated data being logged, as opposed to the actual original request object.
Some middlewares, such as https://github.com/ctavan/express-validator, mutate req.body -- in this case, when sanitizers are run. By the time `errorLogger` or `logger` record, in such a scenario, an incorrect representation of the original request object is logged.

When a request is initiated, I make a deep copy of `req.body` and assign it to `req._originalBody`. When `end` is invoked on logger or when errorLogger is triggered, `req._originalBody` is reassigned back to `req.body` and the key for `_.originalBody` is deleted.