### PR TITLE
Dynamic Log Levels

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1033,6 +1033,59 @@ describe('express-winston', function () {
       });
     });
 
+    describe('when levels set to a function', function () {
+        it('should have custom status level provided by the function when 100 <= statusCode < 400', function () {
+          var testHelperOptions = {
+            next: function (req, res, next) {
+              res.status(200).end('{ "message": "Hi!  I\'m a chunk!" }');
+            },
+            loggerOptions: {
+              level: function(req,res) { return 'silly'; }
+            },
+            transportOptions: {
+              level: 'silly'
+            }
+          };
+          return loggerTestHelper(testHelperOptions).then(function (result) {
+            result.log.level.should.equal('silly');
+          });
+        });
+
+        it('should have custom status level provided by the function when 400 <= statusCode < 500', function () {
+          var testHelperOptions = {
+            next: function (req, res, next) {
+              res.status(403).end('{ "message": "Hi!  I\'m a chunk!" }');
+            },
+            loggerOptions: {
+              level: function(req,res) { return 'silly'; }
+            },
+            transportOptions: {
+              level: 'silly'
+            }
+          };
+          return loggerTestHelper(testHelperOptions).then(function (result) {
+            result.log.level.should.equal('silly');
+          });
+        });
+
+        it('should have custom status level provided by the function when 500 <= statusCode', function () {
+          var testHelperOptions = {
+            next: function (req, res, next) {
+              res.status(500).end('{ "message": "Hi!  I\'m a chunk!" }');
+            },
+            loggerOptions: {
+              level: function(req,res) { return 'silly'; }
+            },
+            transportOptions: {
+              level: 'silly'
+            }
+          };
+          return loggerTestHelper(testHelperOptions).then(function (result) {
+            result.log.level.should.equal('silly');
+          });
+        });
+    });
+
     describe('requestWhitelist option', function () {
       it('should default to global requestWhitelist', function () {
         var options = {


### PR DESCRIPTION
Allow `options.level` to be a function for dynamic level setting.

A project I am working on requires the ability to dynamically set the log level based on deeper inspection of the request and response. I added unit tests based on the existing ones, and everything is passing. I tried to set sane defaults and checks that should preserve the existing behavior of the middleware with `options.level` set to a string or object. Only setting it to a function should behave differently, and that wasn't a valid option before.