### PR TITLE
Respect request filtering of req.body...

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,10 +267,14 @@ exports.logger = function logger(options) {
               }
 
               if (logData.req) {
-                if (filteredBody) {
-                  logData.req.body = filteredBody;
-                } else {
+                if (!filteredBody) {
                   delete logData.req.body;
+                } else if (!_.isEqual(filteredBody, req.body)) {
+                  // Only replace req.body with filtered body if filtered body
+                  // is ACTUALLY filtered, since there's a possibility that
+                  // someone filtered the body through `requestFilter` being
+                  // called on the req.
+                  logData.req.body = filteredBody;
                 }
               }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1246,6 +1246,37 @@ describe('express-winston', function () {
         loggerFn.should.throw();
       });
     });
+
+    describe('requestFilter option', function () {
+      it('should respect request body filtered through `requestFilter` (if not filtered by bodyBlacklist/bodyWhitelist)', function () {
+        var testHelperOptions = {
+          req: {
+            body: {
+              field1: 'foo',
+              field2: 'bar'
+            }
+          },
+          loggerOptions: {
+            bodyBlacklist: [],
+            requestWhitelist: ['method', 'url', 'body'],
+            requestFilter: function(req, propName) {
+              if (propName === 'body') {
+                var jsonbody = JSON.parse(JSON.stringify(req[propName]));
+                delete jsonbody.field2;
+                return jsonbody;
+              }
+              return req[propName];
+            }
+          }
+        };
+
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          result.log.meta.req.should.be.ok();
+          result.log.meta.req.body.field1.should.equal('foo');
+          should.not.exist(result.log.meta.req.body.field2);
+        });
+      });
+    });
   });
 
   describe('.requestWhitelist', function () {


### PR DESCRIPTION
Respect request filtering of req.body when req.body has not already been filtered by bodyBlacklist/bodyWhitelist.

Fixes #142.

Caused by dc4891f45a920c6db3c1e5427b04a9ff4a783b13 and 1cf7afb6126c88d9452d3352bbf4c88dc43277c3.