### PR TITLE
allow msg to accept a function to customize output string

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,7 +65,7 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
     transports: [<WinstonTransport>], // list of all winston transports instances to use.
     winstonInstance: <WinstonLogger>, // a winston logger instance. If this is provided the transports option is ignored.
     level: String or function(req, res) { return String; }, // log level to use, the default is "info". Assign a  function to dynamically set the level based on request and response, or a string to statically set it always at that level. statusLevels must be false for this setting to be used.
-    msg: String // customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}", "HTTP {{req.method}} {{req.url}}".
+    msg: String or function // customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}", "HTTP {{req.method}} {{req.url}}" or function(req, res) { return `${res.statusCode} - ${req.method}` }
     expressFormat: Boolean, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors when colorize set to true
     colorize: Boolean, // Color the text and status code, using the Express/morgan color palette (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
     meta: Boolean, // control whether you want to log the meta data about the request (default to true).
@@ -110,7 +110,7 @@ The logger needs to be added AFTER the express router(`app.router)`) and BEFORE 
 ``` js
     transports: [<WinstonTransport>], // list of all winston transports instances to use.
     winstonInstance: <WinstonLogger>, // a winston logger instance. If this is provided the transports option is ignored
-    msg: String // customize the default logging message. E.g. "{{err.message}} {{res.statusCode}} {{req.method}}".
+    msg: String or function // customize the default logging message. E.g. "{{err.message}} {{res.statusCode}} {{req.method}}" or function(req, res) { return `${res.statusCode} - ${req.method}` }
     baseMeta: Object, // default meta data to be added to log, this will be merged with the error data.
     metaField: String, // if defined, the meta data will be added in this field instead of the meta root object.
     requestFilter: function (req, propName) { return req[propName]; } // A function to filter/return request values, defaults to returning all values allowed by whitelist. If the function returns undefined, the key/value will not be included in the meta.

--- a/index.js
+++ b/index.js
@@ -125,8 +125,8 @@ exports.errorLogger = function errorLogger(options) {
     options.dynamicMeta = options.dynamicMeta || function(req, res, err) { return null; };
 
     // Using mustache style templating
-    var getTemplate = function(msg, options) {
-      return _.template(msg, {interpolate: /\{\{([\s\S]+?)\}\}/g})(options)
+    var getTemplate = function(msg, data) {
+      return _.template(msg, {interpolate: /\{\{([\s\S]+?)\}\}/g})(data)
     };
 
     return function (err, req, res, next) {
@@ -323,7 +323,6 @@ exports.logger = function logger(options) {
             } else {
               msgFormat = expressMsgFormat
             }
-
 
             // Using mustache style templating
             var template = _.template(msgFormat, {

--- a/index.js
+++ b/index.js
@@ -315,6 +315,15 @@ exports.logger = function logger(options) {
               coloredRes.statusCode = chalk[statusColor](res.statusCode);
             }
 
+            var msgFormat = !options.expressFormat ?
+              typeof options.msg === 'function' ? options.msg(req, res) : options.msg
+              : expressMsgFormat
+
+            // Using mustache style templating
+            var template = _.template(msgFormat, {
+              interpolate: /\{\{(.+?)\}\}/g
+            });
+
             var msg = template({req: req, res: _.assign({}, res, coloredRes)});
 
             // This is fire and forget, we don't want logging to hold up the request so don't wait for the callback


### PR DESCRIPTION
I'm not a fan of the msg being a string that's bound by lodash {{}} templating, so why not allow msg to accept a function so I can manipulate rec/res how I want with js and return a string however I want? 