### PR TITLE
move order of middleware definitions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -141,6 +141,11 @@ Alternatively, if you're using a winston logger instance elsewhere and have alre
       return next(new Error("This is an error and it should be logged to the console"));
     });
 
+    router.get('/', function(req, res, next) {
+      res.write('This is a normal request, it should be logged to the console too');
+      res.end();
+    });
+
     // express-winston logger makes sense BEFORE the router and and app-defined methods.
     app.use(expressWinston.logger({
       transports: [
@@ -150,11 +155,6 @@ Alternatively, if you're using a winston logger instance elsewhere and have alre
         })
       ]
     }));
-
-    app.get('/', function(req, res, next) {
-      res.write('This is a normal request, it should be logged to the console too');
-      res.end();
-    });
 
     // Now we can tell the app to use our routing code:
     app.use(router);

--- a/Readme.md
+++ b/Readme.md
@@ -146,7 +146,7 @@ Alternatively, if you're using a winston logger instance elsewhere and have alre
       res.end();
     });
 
-    // express-winston logger makes sense BEFORE the router and and app-defined methods.
+    // express-winston logger makes sense BEFORE the router
     app.use(expressWinston.logger({
       transports: [
         new winston.transports.Console({

--- a/Readme.md
+++ b/Readme.md
@@ -141,12 +141,7 @@ Alternatively, if you're using a winston logger instance elsewhere and have alre
       return next(new Error("This is an error and it should be logged to the console"));
     });
 
-    app.get('/', function(req, res, next) {
-      res.write('This is a normal request, it should be logged to the console too');
-      res.end();
-    });
-
-    // express-winston logger makes sense BEFORE the router.
+    // express-winston logger makes sense BEFORE the router and and app-defined methods.
     app.use(expressWinston.logger({
       transports: [
         new winston.transports.Console({
@@ -155,6 +150,11 @@ Alternatively, if you're using a winston logger instance elsewhere and have alre
         })
       ]
     }));
+
+    app.get('/', function(req, res, next) {
+      res.write('This is a normal request, it should be logged to the console too');
+      res.end();
+    });
 
     // Now we can tell the app to use our routing code:
     app.use(router);


### PR DESCRIPTION
The current example doesn't work because of the order we define the middlewares.

More context on https://github.com/bithavoc/express-winston/issues/169