### PR TITLE
Use req.originalUrl instead of req.url for logs and don't manipulate req.url

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ exports.logger = function logger(options) {
     options.winstonInstance = options.winstonInstance || (new winston.Logger ({ transports: options.transports }));
     options.statusLevels = options.statusLevels || false;
     options.level = options.statusLevels ? levelFromStatus(options) : (options.level || "info");
-    options.msg = options.msg || "HTTP {{req.method}} {{req.url}}";
+    options.msg = options.msg || "HTTP {{req.method}} {{req.originalUrl}}";
     options.baseMeta = options.baseMeta || {};
     options.metaField = options.metaField || null;
     options.colorize = options.colorize || false;
@@ -197,9 +197,9 @@ exports.logger = function logger(options) {
     options.skip = options.skip || exports.defaultSkip;
     options.dynamicMeta = options.dynamicMeta || function(req, res) { return null; };
 
-    var expressMsgFormat = "{{req.method}} {{req.url}} {{res.statusCode}} {{res.responseTime}}ms";
+    var expressMsgFormat = "{{req.method}} {{req.originalUrl}} {{res.statusCode}} {{res.responseTime}}ms";
     if (options.colorize) {
-        expressMsgFormat = chalk.grey("{{req.method}} {{req.url}}") +
+        expressMsgFormat = chalk.grey("{{req.method}} {{req.originalUrl}}") +
           " {{res.statusCode}} " +
           chalk.grey("{{res.responseTime}}ms");
     }
@@ -237,8 +237,6 @@ exports.logger = function logger(options) {
 
             res.end = end;
             res.end(chunk, encoding);
-
-            req.url = req.originalUrl || req.url;
 
             var meta = {};
 


### PR DESCRIPTION
The current implementation overwrites `req.url` since it is used in the log message templates.
This leads to errors and issues like #156. In our case, it makes the express app even crash.

This PR removes the overwrite of `req.url` and switches to `req.originalUrl` for the log messages.
It resolves #156.