### PR TITLE
added exceptionToMeta method for filtering returned meta object

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -117,6 +117,7 @@ The logger needs to be added AFTER the express router(`app.router)`) and BEFORE 
     requestWhitelist: [String] // Array of request properties to log. Overrides global requestWhitelist for this instance
     level: String or function(req, res, err) { return String; }// custom log level for errors (default is 'error'). Assign a function to dynamically set the log level based on request, response, and the exact error.
     dynamicMeta: function(req, res, err) { return [Object]; } // Extract additional meta data from request or response (typically req.user data if using passport). meta must be true for this function to be activated
+    exceptionToMeta: function(error){return Object; } // Function to format the returned meta information on error log. If not given `winston.exception.getAllInfo` will be used by default
 ```
 
 To use winston's existing transports, set `transports` to the values (as in key-value) of the `winston.default.transports` object. This may be done, for example, by using underscorejs: `transports: _.values(winston.default.transports)`.

--- a/index.js
+++ b/index.js
@@ -123,6 +123,7 @@ exports.errorLogger = function errorLogger(options) {
     options.metaField = options.metaField || null;
     options.level = options.level || 'error';
     options.dynamicMeta = options.dynamicMeta || function(req, res, err) { return null; };
+    options.exceptionToMeta = options.exceptionToMeta || winston.exception.getAllInfo;
 
     // Using mustache style templating
     var getTemplate = function(msg, data) {
@@ -131,8 +132,8 @@ exports.errorLogger = function errorLogger(options) {
 
     return function (err, req, res, next) {
 
-        // Let winston gather all the error data.
-        var exceptionMeta = winston.exception.getAllInfo(err);
+      // Let winston gather all the error data
+        var exceptionMeta = options.exceptionToMeta(err);
         exceptionMeta.req = filterObject(req, options.requestWhitelist, options.requestFilter);
 
         if(options.dynamicMeta) {

--- a/test/test.js
+++ b/test/test.js
@@ -229,6 +229,33 @@ describe('express-winston', function () {
       });
     });
 
+    describe.only('exceptionToMeta option', function () {
+      it('should, use exceptionToMeta function when given', function () {
+        function exceptionToMeta(error) {
+          return {
+            stack: error.stack && error.stack.split('\n')
+          };
+        }
+
+        var testHelperOptions = { loggerOptions: { exceptionToMeta: exceptionToMeta } };
+        return errorLoggerTestHelper(testHelperOptions).then(function (result) {
+          result.log.meta.stack.should.be.ok();
+          result.log.meta.should.not.have.property('trace');
+        });
+      });
+
+      it('should, use getAllInfo function when not given', function () {
+        var testHelperOptions = { loggerOptions: { } };
+        return errorLoggerTestHelper(testHelperOptions).then(function (result) {
+          result.log.meta.should.have.property('date');
+          result.log.meta.should.have.property('process');
+          result.log.meta.should.have.property('os');
+          result.log.meta.should.have.property('trace');
+          result.log.meta.should.have.property('stack');
+        });
+      });
+    });
+
     describe('metaField option', function () {
       it('should, when using a custom metaField, log the custom metaField', function () {
         var testHelperOptions = {loggerOptions: {metaField: 'metaField'}};


### PR DESCRIPTION
Added tests to https://github.com/bithavoc/express-winston/pull/149. Could we merge this to main branch so there will be an option to filter meta data on exception. Currently `trace` field is causing too much noise.