### PR TITLE
fix: limit winston to smaller 3, as winston 3 breaks express-winston.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "winston": ">=1.x"
   },
   "peerDependencies": {
-    "winston": ">=1.x"
+    "winston": ">=1.x <3"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
This should helper others, when considering upgrading to winston v3. Npm will display a warning if a user install winston v3. Should be removed after supporting v3. 