### PR TITLE
Support for Winston 3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 #################
 /node_modules
 npm-debug.log
+package-lock.json
 
 #################
 ## Jetbrains

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
-  - "4"
   - "6"
-  - "7"
   - "8"
-  - "9"
   - "10"
-
-script:
-  - "test $TRAVIS_NODE_VERSION  = '0.6' || npm test"
-  - "test $TRAVIS_NODE_VERSION != '0.6' || npm run-script test-coverage"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 3.0.0
+express-winston@3 shouldn't have any breaking changes _of its own_, but there are breaking changes as a result of upgrading winston and Node.js.
+
+express-winston@2.6.0 will be the last version to support winston@2.
+
+#### Breaking changes
+* Drop support for winston < 3. winston@3 includes quite a few breaking changes. Check their [changelog](https://github.com/winstonjs/winston/blob/master/CHANGELOG.md) and [upgrade guide](https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md) to get an idea of winston's breaking changes.
+* Drop support for Node.js < 6. v6 is the oldest version of Node.js [currently supported by the Node.js team](https://github.com/nodejs/Release).
+
+## 2.6.0
+* Add `exceptionToMeta` and `blacklistedMetaFields` for filtering returned meta
+  object ([#173](https://github.com/bithavoc/express-winston/pull/173), @cubbuk)
+
+## 2.5.1
+* Allow `msg` to be a function ([#160](https://github.com/bithavoc/express-winston/pull/160), @brendancwood)
+
+## 2.5.0
+* Reduce memory usage ([#164](https://github.com/bithavoc/express-winston/pull/164), @Kmaschta)
+
 ## 2.4.0
 * Allow `options.level` to be a function for dynamic level setting ([#148](https://github.com/bithavoc/express-winston/pull/148), @CryptArchy)
 

--- a/Readme.md
+++ b/Readme.md
@@ -3,11 +3,13 @@
 
 > [winston](https://github.com/winstonjs/winston) middleware for express.js
 
+[Changelog](CHANGELOG.md)
+
 ## Installation
 
     npm install winston express-winston
 
-(supports node >= 0.10)
+(supports node >= 6)
 
 ## Usage
 
@@ -21,8 +23,8 @@ In `package.json`:
 {
   "dependencies": {
     "...": "...",
-    "winston": "^2.0.0",
-    "express-winston": "^2.0.0",
+    "winston": "^3.0.0",
+    "express-winston": "^3.0.0",
     "...": "..."
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "winston": ">=3.x <4"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">= 6"
   },
   "license": "MIT",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -47,14 +47,14 @@
     }
   },
   "dependencies": {
-    "chalk": "~0.4.0",
-    "lodash": "~4.17.5"
+    "chalk": "^2.4.1",
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "blanket": "^1.2.2",
-    "mocha": "^2.4.5",
+    "mocha": "^5.2.0",
     "node-mocks-http": "^1.5.1",
-    "should": "^8.2.2",
+    "should": "^13.2.3",
     "travis-cov": "^0.2.5",
     "winston": ">=3.x <4",
     "winston-transport": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "blanket": "^1.2.2",
     "mocha": "^2.4.5",
     "node-mocks-http": "^1.5.1",
-    "promise": "^7.1.1",
     "should": "^8.2.2",
     "travis-cov": "^0.2.5",
     "winston": ">=3.x <4",

--- a/package.json
+++ b/package.json
@@ -57,10 +57,11 @@
     "promise": "^7.1.1",
     "should": "^8.2.2",
     "travis-cov": "^0.2.5",
-    "winston": ">=1.x <3"
+    "winston": ">=3.x <4",
+    "winston-transport": "^4.2.0"
   },
   "peerDependencies": {
-    "winston": ">=1.x <3"
+    "winston": ">=3.x <4"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ var Promise = require('promise/lib/es6-extensions');
 var should = require('should');
 var _ = require('lodash');
 var winston = require('winston');
+var Transport = require('winston-transport');
 
 var expressWinston = require('../index.js');
 
@@ -12,21 +13,23 @@ expressWinston.ignoredRoutes.push('/ignored');
 expressWinston.responseWhitelist.push('body');
 expressWinston.bodyBlacklist.push('potato');
 
-var MockTransport = function (test, options) {
-  test.transportInvoked = false;
+class MockTransport extends Transport {
+  constructor(test, options) {
+    super(options || {});
 
-  winston.Transport.call(this, options || {});
+    this._test = test;
+    this._test.transportInvoked = false;
+  }
 
-  this.log = function (level, msg, meta, cb) {
-    test.transportInvoked = true;
-    test.log.level = level;
-    test.log.msg = msg;
-    test.log.meta = meta;
+  log(info, cb) {
+    this._test.transportInvoked = true;
+    this._test.log.level = info.level;
+    this._test.log.msg = info.message;
+    this._test.log.meta = info.meta;
     this.emit('logged');
     return cb();
-  };
-};
-util.inherits(MockTransport, winston.Transport);
+  }
+}
 
 function mockReq(reqMock) {
   var reqSpec = _.extend({

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,6 @@
 var util = require('util');
 
 var mocks = require('node-mocks-http');
-var Promise = require('promise/lib/es6-extensions');
 var should = require('should');
 var _ = require('lodash');
 var winston = require('winston');


### PR DESCRIPTION
Fixes https://github.com/bithavoc/express-winston/issues/163.

## Proposed changes
- [x] Upgrade to winston@3
  * express-winston _shouldn't_ have any breaking changes as a result.
  * winston@3 seems to have quite a few breaking changes though.
    * Biggest one to call out for users is probably that custom transports should be updated. Despite the winston changelog [claiming that transports shouldn't break](https://github.com/winstonjs/winston/blob/3.0.0/CHANGELOG.md#v300-rc0--2017-10-02), my experience is that they definitely do (based on our `MockTransport` used in testing).
  * I think supporting both versions 2 and 3 of winston is going to cause too many headaches for it to be worth it. So just upgrade wholesale to version 3, and this will be a breaking change (and major version bump).
- [x] Upgrade all other dependencies
  * Might as well do it now just in case there are any other breaking changes lurking in other dependencies.
- [x] Update node version support
  * Dropping support for old versions of node should count as a breaking change and therefore require a major version bump, in my opinion. Since we're about to do one for winston@3, might as well throw this in.
  * We're working with some _very_ old versions of node (0.10!). I think we should only support the [currently-supported versions of node](https://github.com/nodejs/Release) at any given time (with maybe a slight grace period for newly-EOL'd versions). Right now, that means we'll support only versions 6, 8, and 10.
  * winston also [dropped support for node versions < 6](https://github.com/winstonjs/winston/blob/3.0.0/CHANGELOG.md#v300-rc0--2017-10-02) in v3
- [ ] ~Use [standard](https://standardjs.com/)~ (postponed until after 3.x)
  * The lack of consistent code formatting makes the code difficult to work with.
  * I want to avoid bikeshedding about code style, so use something that 1) requires no configuration, and 2) is pretty popular.
  * I want to update this now so that it doesn't sit as a longstanding to-do.
- [ ] ~Add package-lock.json (maybe?)~
  * ~Since we'll be on a newer node version, we could take advantage of newer npm features.~
  * ~I'm not sure this makes sense for a library. Thoughts?~

Anything else that really needs to get into the major version bump? Non-breaking changes (almost all of them) should wait until after the major version bump. I don't want this major version bump to have too much scope creep.