### PR TITLE
Support winston 3.x transports and formats

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,11 +46,12 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
 
     app.use(expressWinston.logger({
       transports: [
-        new winston.transports.Console({
-          json: true,
-          colorize: true
-        })
+        new winston.transports.Console()
       ],
+      format: winston.format.combine(
+        winston.format.colorize()
+        winston.format.json()
+      )
       meta: true, // optional: control whether you want to log the meta data about the request (default to true)
       msg: "HTTP {{req.method}} {{req.url}}", // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
       expressFormat: true, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors with colorize set to true
@@ -65,7 +66,8 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
 
 ``` js
     transports: [<WinstonTransport>], // list of all winston transports instances to use.
-    winstonInstance: <WinstonLogger>, // a winston logger instance. If this is provided the transports option is ignored.
+    format: [<logform.Format>], // formatting desired for log output.
+    winstonInstance: <WinstonLogger>, // a winston logger instance. If this is provided the transports and formats options are ignored.
     level: String or function(req, res) { return String; }, // log level to use, the default is "info". Assign a  function to dynamically set the level based on request and response, or a string to statically set it always at that level. statusLevels must be false for this setting to be used.
     msg: String or function // customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}", "HTTP {{req.method}} {{req.url}}" or function(req, res) { return `${res.statusCode} - ${req.method}` }
     expressFormat: Boolean, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors when colorize set to true
@@ -97,11 +99,12 @@ Use `expressWinston.errorLogger(options)` to create a middleware that log the er
     app.use(router); // notice how the router goes first.
     app.use(expressWinston.errorLogger({
       transports: [
-        new winston.transports.Console({
-          json: true,
-          colorize: true
-        })
-      ]
+        new winston.transports.Console()
+      ],
+      format: winston.format.combine(
+        winston.format.colorize()
+        winston.format.json()
+      )
     }));
 ```
 
@@ -111,7 +114,8 @@ The logger needs to be added AFTER the express router(`app.router)`) and BEFORE 
 
 ``` js
     transports: [<WinstonTransport>], // list of all winston transports instances to use.
-    winstonInstance: <WinstonLogger>, // a winston logger instance. If this is provided the transports option is ignored
+    format: [<logform.Format>], // formatting desired for log output
+    winstonInstance: <WinstonLogger>, // a winston logger instance. If this is provided the transports and formats options are ignored.
     msg: String or function // customize the default logging message. E.g. "{{err.message}} {{res.statusCode}} {{req.method}}" or function(req, res) { return `${res.statusCode} - ${req.method}` }
     baseMeta: Object, // default meta data to be added to log, this will be merged with the error data.
     metaField: String, // if defined, the meta data will be added in this field instead of the meta root object.
@@ -153,11 +157,12 @@ Alternatively, if you're using a winston logger instance elsewhere and have alre
     // express-winston logger makes sense BEFORE the router
     app.use(expressWinston.logger({
       transports: [
-        new winston.transports.Console({
-          json: true,
-          colorize: true
-        })
-      ]
+        new winston.transports.Console()
+      ],
+      format: winston.format.combine(
+        winston.format.colorize()
+        winston.format.json()
+      )
     }));
 
     // Now we can tell the app to use our routing code:
@@ -166,11 +171,12 @@ Alternatively, if you're using a winston logger instance elsewhere and have alre
     // express-winston errorLogger makes sense AFTER the router.
     app.use(expressWinston.errorLogger({
       transports: [
-        new winston.transports.Console({
-          json: true,
-          colorize: true
-        })
-      ]
+        new winston.transports.Console()
+      ],
+      format: winston.format.combine(
+        winston.format.colorize()
+        winston.format.json()
+      )
     }));
 
     // Optionally you can include your custom error handler after the logging.

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 //
 var winston = require('winston');
-var util = require('util');
 var chalk = require('chalk');
 
 var _ = require('lodash');
@@ -117,7 +116,10 @@ exports.errorLogger = function errorLogger(options) {
 
     options.requestWhitelist = options.requestWhitelist || exports.requestWhitelist;
     options.requestFilter = options.requestFilter || exports.defaultRequestFilter;
-    options.winstonInstance = options.winstonInstance || (winston.createLogger ({ transports: options.transports }));
+    options.winstonInstance = options.winstonInstance || (winston.createLogger({
+      transports: options.transports,
+      format: options.format
+    }));
     options.msg = options.msg || 'middlewareError';
     options.baseMeta = options.baseMeta || {};
     options.metaField = options.metaField || null;
@@ -192,7 +194,10 @@ exports.logger = function logger(options) {
     options.requestFilter = options.requestFilter || exports.defaultRequestFilter;
     options.responseFilter = options.responseFilter || exports.defaultResponseFilter;
     options.ignoredRoutes = options.ignoredRoutes || exports.ignoredRoutes;
-    options.winstonInstance = options.winstonInstance || (winston.createLogger ({ transports: options.transports }));
+    options.winstonInstance = options.winstonInstance || (winston.createLogger({
+      transports: options.transports,
+      format: options.format
+    }));
     options.statusLevels = options.statusLevels || false;
     options.level = options.statusLevels ? levelFromStatus(options) : (options.level || "info");
     options.msg = options.msg || "HTTP {{req.method}} {{req.url}}";


### PR DESCRIPTION
In their 3.0.0 release, winston deprecated formatting inside transports.
https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md#removed-winstontransportsfileconsolehttp-formatting-options

This PR adds formats to the options passed into the express-winston logger
and errorLogger.

This package also needs a fresh release of typings to DefinitelyTyped, as it's latest version is not compatible with the current winston release.