### PR TITLE
Fix large _.template memory consumption

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Damian Kaczmarek <rush@rushbase.net>
 Robbie Trencheny <me@robbiet.us> (http://robbie.io)
 Ross Brandes <ross.brandes@gmail.com>
 Kévin Maschtaler (https://www.kmaschta.me)
+Matthew Blasius <matthew.blasius@expel.io> (https://expel.io)

--- a/Readme.md
+++ b/Readme.md
@@ -71,7 +71,7 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
     format: [<logform.Format>], // formatting desired for log output.
     winstonInstance: <WinstonLogger>, // a winston logger instance. If this is provided the transports and formats options are ignored.
     level: String or function(req, res) { return String; }, // log level to use, the default is "info". Assign a  function to dynamically set the level based on request and response, or a string to statically set it always at that level. statusLevels must be false for this setting to be used.
-    msg: String or function, // customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}", "HTTP {{req.method}} {{req.url}}" or function(req, res) { return `${res.statusCode} - ${req.method}` }
+    msg: String or function, // customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}", "HTTP {{req.method}} {{req.url}}" or function(req, res) { return `${res.statusCode} - ${req.method}`.  Warning: while supported, returning mustache style interpolation from an options.msg function has performance and memory implications under load.
     expressFormat: Boolean, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors when colorize set to true
     colorize: Boolean, // Color the text and status code, using the Express/morgan color palette (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
     meta: Boolean, // control whether you want to log the meta data about the request (default to true).

--- a/test/test.js
+++ b/test/test.js
@@ -874,6 +874,34 @@ describe('express-winston', function () {
           result.log.msg.should.eql('Foo GET /all-the-things');
         });
       });
+
+      it('can be a function', function () {
+        var testHelperOptions = {
+          loggerOptions: {
+            msg: function (req) { return 'fn ' + req.url; }
+          },
+          req: {
+            url: '/all-the-things'
+          }
+        };
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          result.log.msg.should.eql('fn /all-the-things');
+        });
+      });
+
+      it('can be interpolated when it is a function', function () {
+        var testHelperOptions = {
+          loggerOptions: {
+            msg: function () { return 'fn {{req.url}}'; }
+          },
+          req: {
+            url: '/all-the-things'
+          }
+        };
+        return loggerTestHelper(testHelperOptions).then(function (result) {
+          result.log.msg.should.eql('fn /all-the-things');
+        });
+      });
     });
 
     describe('ignoreRoute option', function () {


### PR DESCRIPTION

**Problem:** In order to support accepting a function for options.msg,
express-winston is calling `_.template` for every request.  This compiles
a brand new lodash template every request.  Under heavy load, this has
significant performance and memory usage implications.

**Solution:** During initialization, make the decision on whether to use
a single cached template or a dynamic function that compiles a template
for each request.  This way, we get the efficiency of a precompiled
template for the more common use cases, while remaining backwards
compatible with published features.

In a future version, it might be worth considering dropping support
for mustache formatting and just have express-winston consumers always
provide a function if they want a custom options.msg.  The api consumer
can use JS template literals if they need templating in their custom
message.