### PR TITLE
_header -> getHeader

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,8 +287,8 @@ exports.logger = function logger(options) {
 
               if (_.includes(responseWhitelist, 'body')) {
                 if (chunk) {
-                  var isJson = (res._headers && res._headers['content-type']
-                    && res._headers['content-type'].indexOf('json') >= 0);
+                  var isJson = (res.getHeader('content-type')
+                    && res.getHeader('content-type').indexOf('json') >= 0);
 
                   logData.res.body = bodyToString(chunk, isJson);
                 }


### PR DESCRIPTION
Currently we cannot add the body in the response with `responseWhitelist: expressWinston.responseWhitelist.concat('body')`, because `_header` is deprecated and crashed the app. This PR goes from `_header` property to `getHeader` function

https://nodejs.org/api/http.html#http_request_getheader_name