### PR TITLE
Build: replace coverage tool blanket with nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ package-lock.json
 #################
 .DS_Store
 lib/.DS_Store
-coverage.html
+coverage
+.nyc_output
 .vimrc

--- a/Readme.md
+++ b/Readme.md
@@ -439,13 +439,9 @@ Run the basic Mocha tests:
 
     npm test
 
-Run the Travis-CI tests (which will fail with < 100% coverage):
+View the coverage report:
 
-    npm run test-travis
-
-Generate the `coverage.html` coverage report:
-
-    npm run test-coverage
+    npx http-server coverage/lcov-report
 
 ## Issues and Collaboration
 

--- a/package.json
+++ b/package.json
@@ -28,34 +28,17 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha --reporter spec",
-    "test-travis": "node_modules/.bin/mocha --require blanket --reporter travis-cov",
-    "test-coverage": "node_modules/.bin/mocha --require blanket --reporter html-cov > coverage.html || true"
-  },
-  "config": {
-    "travis-cov": {
-      "threshold": 100
-    },
-    "blanket": {
-      "pattern": [
-        "index.js"
-      ],
-      "data-cover-never": [
-        "node_modules",
-        "test"
-      ]
-    }
+    "test": "nyc mocha && nyc report --reporter lcov"
   },
   "dependencies": {
     "chalk": "^2.4.1",
     "lodash": "^4.17.10"
   },
   "devDependencies": {
-    "blanket": "^1.2.2",
     "mocha": "^5.2.0",
     "node-mocks-http": "^1.5.1",
+    "nyc": "^14.1.1",
     "should": "^13.2.3",
-    "travis-cov": "^0.2.5",
     "winston": ">=3.x <4",
     "winston-transport": "^4.2.0"
   },


### PR DESCRIPTION
[Blanket](https://www.npmjs.com/package/blanket) is not actively maintained and nyc is the most popular coverage tool. Also the npm script `test-coverage` is not working anyway.