### PR TITLE
#66 nested request and response whitelist support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Robbie Trencheny <me@robbiet.us> (http://robbie.io)
 Ross Brandes <ross.brandes@gmail.com>
 Kévin Maschtaler (https://www.kmaschta.me)
 Matthew Blasius <matthew.blasius@expel.io> (https://expel.io)
+Maxime David <contact@maximedavid.fr>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.0
+* Added: options.headerBlacklist ([#217](https://github.com/bithavoc/express-winston/pull/217), @maxday)
+
 ## 3.2.1
 * Added: options.skip ([#214](https://github.com/bithavoc/express-winston/pull/214), [#147](https://github.com/bithavoc/express-winston/pull/147), @ahnkee)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.1
+* Added: options.skip ([#214](https://github.com/bithavoc/express-winston/pull/214), [#147](https://github.com/bithavoc/express-winston/pull/147), @ahnkee)
+
 ## 3.2.0
 * Replaced: _header -> getHeader ([#210](https://github.com/bithavoc/express-winston/pull/210), @Gregoirevda)
 * Replaced coverage tool blanket with nyc ([#211](https://github.com/bithavoc/express-winston/pull/211), @golopot)

--- a/Readme.md
+++ b/Readme.md
@@ -88,6 +88,7 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
     bodyBlacklist: [String], // Array of body properties to omit from logs. Overrides global bodyBlacklist for this instance
     ignoredRoutes: [String], // Array of paths to ignore/skip logging. Overrides global ignoredRoutes for this instance
     dynamicMeta: function(req, res) { return [Object]; } // Extract additional meta data from request or response (typically req.user data if using passport). meta must be true for this function to be activated
+    headerBlacklist: [String], // Array of headers to omit from logs. Applied after any previous filters.
 
 ```
 
@@ -123,6 +124,7 @@ The logger needs to be added AFTER the express router(`app.router)`) and BEFORE 
     metaField: String, // if defined, the meta data will be added in this field instead of the meta root object.
     requestFilter: function (req, propName) { return req[propName]; } // A function to filter/return request values, defaults to returning all values allowed by whitelist. If the function returns undefined, the key/value will not be included in the meta.
     requestWhitelist: [String] // Array of request properties to log. Overrides global requestWhitelist for this instance
+    headerBlacklist: [String], // Array of headers to omit from logs. Applied after any previous filters.
     level: String or function(req, res, err) { return String; }// custom log level for errors (default is 'error'). Assign a function to dynamically set the log level based on request, response, and the exact error.
     dynamicMeta: function(req, res, err) { return [Object]; } // Extract additional meta data from request or response (typically req.user data if using passport). meta must be true for this function to be activated
     exceptionToMeta: function(error){return Object; } // Function to format the returned meta information on error log. If not given `winston.exception.getAllInfo` will be used by default

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ exports.ignoredRoutes = [];
  * @return {*}
  */
 exports.defaultRequestFilter = function (req, propName) {
-    return req[propName];
+    return _.get(req, propName);
 };
 
 /**
@@ -82,7 +82,7 @@ exports.defaultHeaderBlacklist = [];
  * @return {*}
  */
 exports.defaultResponseFilter = function (res, propName) {
-    return res[propName];
+    return _.get(res, propName);
 };
 
 /**
@@ -102,7 +102,7 @@ function filterObject(originalObj, whiteList, headerBlacklist, initialFilter) {
         var value = initialFilter(originalObj, propName);
 
         if(typeof (value) !== 'undefined') {
-            obj[propName] = value;
+            _.set(obj, propName, value);
             fieldsSet = true;
             if(propName === 'headers') {
                 [].concat(headerBlacklist).forEach(function (headerName) {

--- a/index.js
+++ b/index.js
@@ -304,7 +304,7 @@ exports.logger = function logger(options) {
 
               logData.res = res;
 
-              if (_.includes(responseWhitelist, 'body')) {
+              if (_.includes(responseWhitelist.map(term => term.split('.')[0]), 'body')) {
                 if (chunk) {
                   var isJson = (res.getHeader('content-type')
                     && res.getHeader('content-type').indexOf('json') >= 0);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "middleware",
     "colors"
   ],
-  "version": "3.2.0",
+  "version": "3.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/bithavoc/express-winston.git"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "middleware",
     "colors"
   ],
-  "version": "3.2.1",
+  "version": "3.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/bithavoc/express-winston.git"

--- a/test/test.js
+++ b/test/test.js
@@ -280,6 +280,19 @@ describe('express-winston', function () {
           result.log.meta.req.should.not.have.property('method');
         });
       });
+
+      it('should work with nested requestWhitelist', function () {
+        var options = {
+          req: {foo: {test: "bar"}},
+          loggerOptions: {
+            requestWhitelist: ['foo.test']
+          }
+        };
+        return errorLoggerTestHelper(options).then(function (result) {
+          result.log.meta.req.should.have.property('foo');
+          result.log.meta.req.foo.should.have.property('test');
+        });  
+      });
     });
 
     describe('dynamicMeta option', function () {
@@ -1281,6 +1294,19 @@ describe('express-winston', function () {
         return loggerTestHelper(options).then(function (result) {
           result.log.meta.res.should.have.property('foo');
           result.log.meta.res.should.not.have.property('method');
+        });
+      });
+
+      it('should worth with nested responseWhitelist', function () {
+        var options = {
+          res: {foo: {test: "bar"}},
+          loggerOptions: {
+            responseWhitelist: ['foo.test']
+          }
+        };
+        return loggerTestHelper(options).then(function (result) {
+          result.log.meta.res.should.have.property('foo');
+          result.log.meta.res.foo.should.have.property('test');
         });
       });
     });


### PR DESCRIPTION
This is a minimal solution as suggested by @mbonig in #66.
This will work as expected for the default response/request filters.  For user implementations that whitelist nested values it will be up to the user to implement the functionality correctly (if not nested whitelist is present it should work as usual).

To the point made in #66 about passing the filter a trimmed object - I would argue this isn't required, and is already not what you expect today, even without nesting.