### PR TITLE
add skip option to error logger

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -127,6 +127,7 @@ The logger needs to be added AFTER the express router(`app.router)`) and BEFORE 
     dynamicMeta: function(req, res, err) { return [Object]; } // Extract additional meta data from request or response (typically req.user data if using passport). meta must be true for this function to be activated
     exceptionToMeta: function(error){return Object; } // Function to format the returned meta information on error log. If not given `winston.exception.getAllInfo` will be used by default
     blacklistedMetaFields: [String] // fields to blacklist from meta data
+    skip: function(req, res, err) { return false; } // A function to determine if logging is skipped, defaults to returning false.
 ```
 
 To use winston's existing transports, set `transports` to the values (as in key-value) of the `winston.default.transports` object. This may be done, for example, by using underscorejs: `transports: _.values(winston.default.transports)`.

--- a/test/test.js
+++ b/test/test.js
@@ -363,6 +363,31 @@ describe('express-winston', function () {
         loggerFn.should.throw();
       });
     });
+
+    describe('skip option', function() {
+      it('should log error by default', function() {
+        var options = {
+          req: {foo: "bar"}
+        };
+
+         return errorLoggerTestHelper(options).then(function (result) {
+          result.transportInvoked.should.eql(true);
+        });
+      });
+
+       it('should not log error when function returns true', function() {
+        var options = {
+          req: {foo: "bar"},
+          loggerOptions: {
+            skip: function() {return true;}
+          }
+        };
+
+         return errorLoggerTestHelper(options).then(function (result) {
+          result.transportInvoked.should.eql(false);
+        });
+      });
+    });
   });
 
   describe('.logger()', function () {


### PR DESCRIPTION
Adds `skip` option to error logging, like the one that exists for info logging.