### PR TITLE
Add an headerBlacklist option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Robbie Trencheny <me@robbiet.us> (http://robbie.io)
 Ross Brandes <ross.brandes@gmail.com>
 Kévin Maschtaler (https://www.kmaschta.me)
 Matthew Blasius <matthew.blasius@expel.io> (https://expel.io)
+Maxime David <contact@maximedavid.fr>

--- a/Readme.md
+++ b/Readme.md
@@ -88,6 +88,7 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
     bodyBlacklist: [String], // Array of body properties to omit from logs. Overrides global bodyBlacklist for this instance
     ignoredRoutes: [String], // Array of paths to ignore/skip logging. Overrides global ignoredRoutes for this instance
     dynamicMeta: function(req, res) { return [Object]; } // Extract additional meta data from request or response (typically req.user data if using passport). meta must be true for this function to be activated
+    headerBlacklist: [String], // Array of headers name to omit from logs. Applied after any previous filters.
 
 ```
 
@@ -123,6 +124,7 @@ The logger needs to be added AFTER the express router(`app.router)`) and BEFORE 
     metaField: String, // if defined, the meta data will be added in this field instead of the meta root object.
     requestFilter: function (req, propName) { return req[propName]; } // A function to filter/return request values, defaults to returning all values allowed by whitelist. If the function returns undefined, the key/value will not be included in the meta.
     requestWhitelist: [String] // Array of request properties to log. Overrides global requestWhitelist for this instance
+    headerBlacklist: [String], // Array of headers name to omit from logs. Applied after any previous filters.
     level: String or function(req, res, err) { return String; }// custom log level for errors (default is 'error'). Assign a function to dynamically set the log level based on request, response, and the exact error.
     dynamicMeta: function(req, res, err) { return [Object]; } // Extract additional meta data from request or response (typically req.user data if using passport). meta must be true for this function to be activated
     exceptionToMeta: function(error){return Object; } // Function to format the returned meta information on error log. If not given `winston.exception.getAllInfo` will be used by default

--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,7 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
     bodyBlacklist: [String], // Array of body properties to omit from logs. Overrides global bodyBlacklist for this instance
     ignoredRoutes: [String], // Array of paths to ignore/skip logging. Overrides global ignoredRoutes for this instance
     dynamicMeta: function(req, res) { return [Object]; } // Extract additional meta data from request or response (typically req.user data if using passport). meta must be true for this function to be activated
-    headerBlacklist: [String], // Array of headers name to omit from logs. Applied after any previous filters.
+    headerBlacklist: [String], // Array of headers to omit from logs. Applied after any previous filters.
 
 ```
 
@@ -124,7 +124,7 @@ The logger needs to be added AFTER the express router(`app.router)`) and BEFORE 
     metaField: String, // if defined, the meta data will be added in this field instead of the meta root object.
     requestFilter: function (req, propName) { return req[propName]; } // A function to filter/return request values, defaults to returning all values allowed by whitelist. If the function returns undefined, the key/value will not be included in the meta.
     requestWhitelist: [String] // Array of request properties to log. Overrides global requestWhitelist for this instance
-    headerBlacklist: [String], // Array of headers name to omit from logs. Applied after any previous filters.
+    headerBlacklist: [String], // Array of headers to omit from logs. Applied after any previous filters.
     level: String or function(req, res, err) { return String; }// custom log level for errors (default is 'error'). Assign a function to dynamically set the log level based on request, response, and the exact error.
     dynamicMeta: function(req, res, err) { return [Object]; } // Extract additional meta data from request or response (typically req.user data if using passport). meta must be true for this function to be activated
     exceptionToMeta: function(error){return Object; } // Function to format the returned meta information on error log. If not given `winston.exception.getAllInfo` will be used by default

--- a/index.js
+++ b/index.js
@@ -70,6 +70,12 @@ exports.defaultRequestFilter = function (req, propName) {
 };
 
 /**
+ * A default list of headers in the request object that are not allowed to be logged.
+ * @type {Array}
+ */
+exports.defaultHeaderBlacklist = [];
+
+/**
  * A default function to filter the properties of the res object.
  * @param res
  * @param propName
@@ -87,7 +93,7 @@ exports.defaultSkip = function() {
   return false;
 };
 
-function filterObject(originalObj, whiteList, initialFilter) {
+function filterObject(originalObj, whiteList, headerBlacklist, initialFilter) {
 
     var obj = {};
     var fieldsSet = false;
@@ -98,7 +104,16 @@ function filterObject(originalObj, whiteList, initialFilter) {
         if(typeof (value) !== 'undefined') {
             obj[propName] = value;
             fieldsSet = true;
+            if(propName === 'headers') {
+                [].concat(headerBlacklist).forEach(function (headerName) {
+                    var lowerCaseHeaderName = headerName.toLowerCase();
+                    if(obj[propName].hasOwnProperty(lowerCaseHeaderName)) {
+                        delete obj[propName][lowerCaseHeaderName];
+                }
+              })
+            }
         }
+
     });
 
     return fieldsSet?obj:undefined;
@@ -148,6 +163,7 @@ exports.errorLogger = function errorLogger(options) {
 
     options.requestWhitelist = options.requestWhitelist || exports.requestWhitelist;
     options.requestFilter = options.requestFilter || exports.defaultRequestFilter;
+    options.headerBlacklist = options.headerBlacklist || exports.defaultHeaderBlacklist;
     options.winstonInstance = options.winstonInstance || (winston.createLogger({
       transports: options.transports,
       format: options.format
@@ -172,7 +188,7 @@ exports.errorLogger = function errorLogger(options) {
     return function (err, req, res, next) {
         // Let winston gather all the error data
         var exceptionMeta = _.omit(options.exceptionToMeta(err), options.blacklistedMetaFields);
-        exceptionMeta.req = filterObject(req, options.requestWhitelist, options.requestFilter);
+        exceptionMeta.req = filterObject(req, options.requestWhitelist, options.headerBlacklist, options.requestFilter);
 
         if(options.dynamicMeta) {
             var dynamicMeta = options.dynamicMeta(req, res, err);
@@ -224,6 +240,7 @@ exports.logger = function logger(options) {
     options.requestWhitelist = options.requestWhitelist || exports.requestWhitelist;
     options.bodyWhitelist = options.bodyWhitelist || exports.bodyWhitelist;
     options.bodyBlacklist = options.bodyBlacklist || exports.bodyBlacklist;
+    options.headerBlacklist = options.headerBlacklist || exports.defaultHeaderBlacklist;
     options.responseWhitelist = options.responseWhitelist || exports.responseWhitelist;
     options.requestFilter = options.requestFilter || exports.defaultRequestFilter;
     options.responseFilter = options.responseFilter || exports.defaultResponseFilter;
@@ -296,8 +313,9 @@ exports.logger = function logger(options) {
                 }
               }
 
-              logData.req = filterObject(req, requestWhitelist, options.requestFilter);
-              logData.res = filterObject(res, responseWhitelist, options.responseFilter);
+
+              logData.req = filterObject(req, requestWhitelist, options.headerBlacklist, options.requestFilter);
+              logData.res = filterObject(res, responseWhitelist, options.headerBlacklist, options.responseFilter);
 
               var bodyWhitelist = _.union(options.bodyWhitelist, (req._routeWhitelists.body || []));
               var blacklist = _.union(options.bodyBlacklist, (req._routeBlacklists.body || []));
@@ -307,15 +325,15 @@ exports.logger = function logger(options) {
               if ( req.body !== undefined ) {
                   if (blacklist.length > 0 && bodyWhitelist.length === 0) {
                     var whitelist = _.difference(Object.keys(req.body), blacklist);
-                    filteredBody = filterObject(req.body, whitelist, options.requestFilter);
+                    filteredBody = filterObject(req.body, whitelist, options.headerBlacklist, options.requestFilter);
                   } else if (
                     requestWhitelist.indexOf('body') !== -1 &&
                     bodyWhitelist.length === 0 &&
                     blacklist.length === 0
                   ) {
-                    filteredBody = filterObject(req.body, Object.keys(req.body), options.requestFilter);
+                    filteredBody = filterObject(req.body, Object.keys(req.body), options.headerBlacklist, options.requestFilter);
                   } else {
-                    filteredBody = filterObject(req.body, bodyWhitelist, options.requestFilter);
+                    filteredBody = filterObject(req.body, bodyWhitelist, options.headerBlacklist, options.requestFilter);
                   }
               }
 

--- a/index.js
+++ b/index.js
@@ -313,7 +313,6 @@ exports.logger = function logger(options) {
                 }
               }
 
-
               logData.req = filterObject(req, requestWhitelist, options.headerBlacklist, options.requestFilter);
               logData.res = filterObject(res, responseWhitelist, options.headerBlacklist, options.responseFilter);
 

--- a/index.js
+++ b/index.js
@@ -106,11 +106,11 @@ function filterObject(originalObj, whiteList, headerBlacklist, initialFilter) {
             fieldsSet = true;
             if(propName === 'headers') {
                 [].concat(headerBlacklist).forEach(function (headerName) {
-                    var lowerCaseHeaderName = headerName.toLowerCase();
+                    var lowerCaseHeaderName = headerName ? headerName.toLowerCase() : null;
                     if(obj[propName].hasOwnProperty(lowerCaseHeaderName)) {
                         delete obj[propName][lowerCaseHeaderName];
-                }
-              })
+                    }
+                })
             }
         }
 


### PR DESCRIPTION
Hello !

The use case here is to prevent logging some sensitive content stored in headers (such as cookies or authorization bearer tokens)

I know this is already achievable using requestFilter option, but it seems to me that obfuscating headers is a common practice which should not require extra code in requestFilter. 

What do you think ?


Content of this PR : 

- new option : headerBlacklist
- default option value : []
- tests
- deletion of one duplicated test

Thanks for reviewing this PR, let me know what do you think, I tried to ship production code ready but any comments is appreciated.

:)

