### PR TITLE
Enhance "metaField" and add "requestField and "responseField" options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+chaset = utf-8
+trim_trailing_whitespace = true
+ij_javascript_use_semicolon_after_statement = true
+ij_javascript_space_before_function_left_parenth = true
+ij_javascript_space_before_method_left_brace = true
+ij_javascript_space_before_method_parentheses = false
+
+[test/*.js]
+indent_size = 2
+
+[package.json]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Ross Brandes <ross.brandes@gmail.com>
 Kévin Maschtaler (https://www.kmaschta.me)
 Matthew Blasius <matthew.blasius@expel.io> (https://expel.io)
 Maxime David <contact@maximedavid.fr>
+Matt Morrissette <yinzara@gmail.com> (https://github.com/yinzara)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 4.0.0
+* Changed `metaField` configuration property functionality (see Readme.md) ([#209](https://github.com/bithavoc/express-winston/issues/209)) - BREAKING CHANGE
+* Moved type definitions to be embedded inside library ([#123](https://github.com/bithavoc/express-winston/issues/123))
+* Added "files" to package.json to reduce unnecessary files in released package
+* Added StackDriver/Google Cloud Logging specific instructions to Readme.md
+* Added `requestField` and `responseField` options to allow storing the request and response in different metadata fields (or not at all) 
+* Fixed `meta` configuration option on `errorLogger` (was not functioning at all)
+* Added .editorconfig and reformatted library to match
+
 ## 3.3.0
 * Added: options.headerBlacklist ([#217](https://github.com/bithavoc/express-winston/pull/217), @maxday)
 

--- a/Readme.md
+++ b/Readme.md
@@ -347,7 +347,7 @@ app.use(expressWinston.logger({
         httpRequest.requestUrl = `${req.protocol}://${req.hostname}${req.originalUrl}`
         httpRequest.protocol = `${req.protocol}/${req.httpVersion}`
         // httpRequest.remoteIp = req.ip // this includes both ipv6 and ipv4 addresses separated by ':'
-        httpRequest.remoteIp = req.ip.indexOf(':') >= 0 ? req.ip.substring(req.lastIndexOf(':') + 1) : req.ip   // just ipv4
+        httpRequest.remoteIp = req.ip.indexOf(':') >= 0 ? req.ip.substring(req.ip.lastIndexOf(':') + 1) : req.ip   // just ipv4
         httpRequest.requestSize = req.socket.bytesRead
         httpRequest.userAgent = req.get("User-Agent")
         httpRequest.referrer = req.get("Referrer")

--- a/Readme.md
+++ b/Readme.md
@@ -336,8 +336,8 @@ app.use(expressWinston.logger({
     transports: [new LoggingWinston({})],
     metaField: null, //this causes the metadata to be stored at the root of the log entry
     responseField: null, // this prevents the response from being included in the metadata (including body and status code)
-    requestWhitelist: ["headers", "query"],  //these are not included in the standard StackDriver httpRequest
-    responseWhitelist: ["body"], // this populates the `res.body` so we can get the response size (not required)
+    requestWhitelist: ['headers', 'query'],  //these are not included in the standard StackDriver httpRequest
+    responseWhitelist: ['body'], // this populates the `res.body` so we can get the response size (not required)
     dynamicMeta:  (req, res) => {
       const httpRequest = {}
       const meta = {}
@@ -349,8 +349,8 @@ app.use(expressWinston.logger({
         // httpRequest.remoteIp = req.ip // this includes both ipv6 and ipv4 addresses separated by ':'
         httpRequest.remoteIp = req.ip.indexOf(':') >= 0 ? req.ip.substring(req.ip.lastIndexOf(':') + 1) : req.ip   // just ipv4
         httpRequest.requestSize = req.socket.bytesRead
-        httpRequest.userAgent = req.get("User-Agent")
-        httpRequest.referrer = req.get("Referrer")
+        httpRequest.userAgent = req.get('User-Agent')
+        httpRequest.referrer = req.get('Referrer')
       }
     
       if (res) {
@@ -361,9 +361,9 @@ app.use(expressWinston.logger({
           nanos: ( res.responseTime % 1000 ) * 1000000
         }
         if (res.body) {
-          if (typeof res.body === "object") {
+          if (typeof res.body === 'object') {
             httpRequest.responseSize = JSON.stringify(res.body).length
-          } else if (typeof res.body === "string") {
+          } else if (typeof res.body === 'string') {
             httpRequest.responseSize = res.body.length
           }
         }
@@ -371,7 +371,6 @@ app.use(expressWinston.logger({
       return meta
     }
 }));
-
 ```
 
 ## Global Whitelists and Blacklists

--- a/Readme.md
+++ b/Readme.md
@@ -344,8 +344,8 @@ app.use(expressWinston.logger({
       if (req) {
         meta.httpRequest = httpRequest
         httpRequest.requestMethod = req.method
-        httpRequest.requestUrl = `${req.protocol}://${req.hostname}${req.originalUrl}`
-        httpRequest.protocol = `${req.protocol}/${req.httpVersion}`
+        httpRequest.requestUrl = `${req.protocol}://${req.get('host')}${req.originalUrl}`
+        httpRequest.protocol = `HTTP/${req.httpVersion}`
         // httpRequest.remoteIp = req.ip // this includes both ipv6 and ipv4 addresses separated by ':'
         httpRequest.remoteIp = req.ip.indexOf(':') >= 0 ? req.ip.substring(req.ip.lastIndexOf(':') + 1) : req.ip   // just ipv4
         httpRequest.requestSize = req.socket.bytesRead

--- a/Readme.md
+++ b/Readme.md
@@ -338,7 +338,7 @@ app.use(expressWinston.logger({
   requestField: "httpRequest",
   responseField: "httpRequest",
   requestWhitelist: ["requestMethod", "requestUrl", "protocol", "remoteIp", "requestSize", "userAgent", "referrer"],
-  responseWhitelist: ["status", "responseSize", "responseTime", "latency"],
+  responseWhitelist: ["status", "responseSize", "latency"],
   requestFilter: function (req, propName) {
     switch(propName) {
       case "requestMethod":
@@ -369,7 +369,10 @@ app.use(expressWinston.logger({
           typeof res.body === 'string' ?
             res.body.length : undefined;
       case "latency":
-        return res.responseTime;
+        return {
+          seconds: Math.round(res.responseTime / 1000),
+          nanos: (res.responseTime - Math.round(res.responseTime / 1000) * 1000) * 1000000
+        };
       default:
         return undefined;
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for express-winston 3.0
+// Type definitions for express-winston 4.0
 // Project: https://github.com/bithavoc/express-winston#readme
 // Definitions by: Alex Brick <https://github.com/bricka>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,114 @@
+// Type definitions for express-winston 3.0
+// Project: https://github.com/bithavoc/express-winston#readme
+// Definitions by: Alex Brick <https://github.com/bricka>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { ErrorRequestHandler, Handler, Request, Response } from 'express';
+import { Format } from 'logform';
+import * as winston from 'winston';
+import * as Transport from 'winston-transport';
+
+export interface FilterRequest extends Request {
+    [other: string]: any;
+}
+
+export interface FilterResponse extends Response {
+    [other: string]: any;
+}
+
+export type DynamicMetaFunction = (req: Request, res: Response, err: Error) => object;
+export type DynamicLevelFunction = (req: Request, res: Response, err: Error) => string;
+export type RequestFilter = (req: FilterRequest, propName: string) => any;
+export type ResponseFilter = (res: FilterResponse, propName: string) => any;
+export type RouteFilter = (req: Request, res: Response) => boolean;
+export type MessageTemplate = string | ((req: Request, res: Response) => string);
+
+export interface BaseLoggerOptions {
+    baseMeta?: object;
+    bodyBlacklist?: string[];
+    bodyWhitelist?: string[];
+    colorize?: boolean;
+    dynamicMeta?: DynamicMetaFunction;
+    expressFormat?: boolean;
+    format?: Format;
+    ignoreRoute?: RouteFilter;
+    ignoredRoutes?: string[];
+    level?: string | DynamicLevelFunction;
+    meta?: boolean;
+    metaField?: string;
+    requestField?: string;
+    responseField?: string;
+    msg?: MessageTemplate;
+    requestFilter?: RequestFilter;
+    requestWhitelist?: string[];
+    responseFilter?: ResponseFilter;
+    responseWhitelist?: string[];
+    skip?: RouteFilter;
+    statusLevels?: {
+        error?: string;
+        success?: string;
+        warn?: string;
+    };
+}
+
+export interface LoggerOptionsWithTransports extends BaseLoggerOptions {
+    transports: Transport[];
+}
+
+export interface LoggerOptionsWithWinstonInstance extends BaseLoggerOptions {
+    winstonInstance: winston.Logger;
+}
+
+export type LoggerOptions = LoggerOptionsWithTransports | LoggerOptionsWithWinstonInstance;
+
+export function logger(options: LoggerOptions): Handler;
+
+export interface BaseErrorLoggerOptions {
+    baseMeta?: object;
+    dynamicMeta?: DynamicMetaFunction;
+    format?: Format;
+    level?: string | DynamicLevelFunction;
+    meta?: boolean;
+    metaField?: string;
+    requestField?: string;
+    msg?: MessageTemplate;
+    requestFilter?: RequestFilter;
+    requestWhitelist?: string[];
+}
+
+export interface ErrorLoggerOptionsWithTransports extends BaseErrorLoggerOptions {
+    transports: Transport[];
+}
+
+export interface ErrorLoggerOptionsWithWinstonInstance extends BaseErrorLoggerOptions {
+    winstonInstance: winston.Logger;
+}
+
+export type ErrorLoggerOptions = ErrorLoggerOptionsWithTransports | ErrorLoggerOptionsWithWinstonInstance;
+
+export function errorLogger(options: ErrorLoggerOptions): ErrorRequestHandler;
+
+export let requestWhitelist: string[];
+
+export let bodyWhitelist: string[];
+
+export let bodyBlacklist: string[];
+
+export let responseWhitelist: string[];
+
+export let ignoredRoutes: string[];
+
+export let defaultRequestFilter: RequestFilter;
+
+export let defaultResponseFilter: ResponseFilter;
+
+export function defaultSkip(): boolean;
+
+export interface ExpressWinstonRequest extends Request {
+    _routeWhitelists: {
+        body: string[];
+        req: string[];
+        res: string[];
+    };
+}

--- a/index.js
+++ b/index.js
@@ -89,9 +89,21 @@ exports.defaultResponseFilter = function (res, propName) {
  * A default function to decide whether skip logging of particular request. Doesn't skip anything (i.e. log all requests).
  * @return always false
  */
-exports.defaultSkip = function() {
-  return false;
+exports.defaultSkip = function () {
+    return false;
 };
+
+/**
+ * The property of the metadata of the log entry that the filtered HTTP request is stored in (default 'req')
+ * @type {string}
+ */
+exports.requestField = 'req';
+
+/**
+ * The property of the metadata of the log entry that the filtered HTTP response is stored in (default 'res')
+ * @type {string}
+ */
+exports.responseField = 'res';
 
 function filterObject(originalObj, whiteList, headerBlacklist, initialFilter) {
 
@@ -100,32 +112,30 @@ function filterObject(originalObj, whiteList, headerBlacklist, initialFilter) {
 
     [].concat(whiteList).forEach(function (propName) {
         var value = initialFilter(originalObj, propName);
-
         if(typeof (value) !== 'undefined') {
             _.set(obj, propName, value);
             fieldsSet = true;
-            if(propName === 'headers') {
+            if (propName === 'headers') {
                 [].concat(headerBlacklist).forEach(function (headerName) {
                     var lowerCaseHeaderName = headerName ? headerName.toLowerCase() : null;
-                    if(obj[propName].hasOwnProperty(lowerCaseHeaderName)) {
+                    if (obj[propName].hasOwnProperty(lowerCaseHeaderName)) {
                         delete obj[propName][lowerCaseHeaderName];
                     }
-                })
+                });
             }
         }
-
     });
 
-    return fieldsSet?obj:undefined;
+    return fieldsSet ? obj : undefined;
 }
 
 function getTemplate(loggerOptions, templateOptions) {
     if (loggerOptions.expressFormat) {
-        var expressMsgFormat = "{{req.method}} {{req.url}} {{res.statusCode}} {{res.responseTime}}ms";
+        var expressMsgFormat = '{{req.method}} {{req.url}} {{res.statusCode}} {{res.responseTime}}ms';
         if (loggerOptions.colorize) {
-            expressMsgFormat = chalk.grey("{{req.method}} {{req.url}}") +
-                " {{res.statusCode}} " +
-                chalk.grey("{{res.responseTime}}ms");
+            expressMsgFormat = chalk.grey('{{req.method}} {{req.url}}') +
+                ' {{res.statusCode}} ' +
+                chalk.grey('{{res.responseTime}}ms');
         }
 
         return _.template(expressMsgFormat, templateOptions);
@@ -148,14 +158,13 @@ function getTemplate(loggerOptions, templateOptions) {
         // interpolation, we'll compile a new template for each request.
         // Warning: this eats a ton of memory under heavy load.
         return _.template(m, templateOptions)(data);
-    }
+    };
 }
 
 //
 // ### function errorLogger(options)
 // #### @options {Object} options to initialize the middleware.
 //
-
 
 exports.errorLogger = function errorLogger(options) {
 
@@ -165,18 +174,19 @@ exports.errorLogger = function errorLogger(options) {
     options.requestFilter = options.requestFilter || exports.defaultRequestFilter;
     options.headerBlacklist = options.headerBlacklist || exports.defaultHeaderBlacklist;
     options.winstonInstance = options.winstonInstance || (winston.createLogger({
-      transports: options.transports,
-      format: options.format
+        transports: options.transports,
+        format: options.format
     }));
     options.msg = options.msg || 'middlewareError';
     options.baseMeta = options.baseMeta || {};
-    options.metaField = options.metaField || null;
+    options.metaField = options.metaField === null || options.metaField === 'null' ? null : options.metaField || 'meta';
     options.level = options.level || 'error';
-    options.dynamicMeta = options.dynamicMeta || function(req, res, err) { return null; };
+    options.dynamicMeta = options.dynamicMeta || function (req, res, err) { return null; };
     const exceptionHandler = new winston.ExceptionHandler(options.winstonInstance);
     options.exceptionToMeta = options.exceptionToMeta || exceptionHandler.getAllInfo.bind(exceptionHandler);
     options.blacklistedMetaFields = options.blacklistedMetaFields || [];
     options.skip = options.skip || exports.defaultSkip;
+    options.requestField = options.requestField === null || options.requestField === 'null' ? null : options.requestField || exports.requestField;
 
     // backwards comparability.
     // just in case they're using the same options object as exports.logger.
@@ -188,17 +198,29 @@ exports.errorLogger = function errorLogger(options) {
     return function (err, req, res, next) {
         // Let winston gather all the error data
         var exceptionMeta = _.omit(options.exceptionToMeta(err), options.blacklistedMetaFields);
-        exceptionMeta.req = filterObject(req, options.requestWhitelist, options.headerBlacklist, options.requestFilter);
+        if (options.meta !== false) {
+            if (options.requestField !== null) {
+                exceptionMeta[options.requestField] = filterObject(req, options.requestWhitelist, options.headerBlacklist, options.requestFilter);
+            }
 
-        if(options.dynamicMeta) {
-            var dynamicMeta = options.dynamicMeta(req, res, err);
-            exceptionMeta = _.assign(exceptionMeta, dynamicMeta);
+            if (options.dynamicMeta) {
+                var dynamicMeta = options.dynamicMeta(req, res, err);
+                exceptionMeta = _.assign(exceptionMeta, dynamicMeta);
+            }
         }
 
         if (options.metaField) {
-            var newMeta = {};
-            newMeta[options.metaField] = exceptionMeta;
-            exceptionMeta = newMeta;
+            var fields;
+            if (Array.isArray(options.metaField)) {
+                fields = options.metaField;
+            } else {
+                fields = options.metaField.split('.');
+            }
+            _(fields).reverse().forEach(field => {
+                var newMeta = {};
+                newMeta[field] = exceptionMeta;
+                exceptionMeta = newMeta;
+            });
         }
 
         exceptionMeta = _.assign(exceptionMeta, options.baseMeta);
@@ -206,12 +228,11 @@ exports.errorLogger = function errorLogger(options) {
         var level = _.isFunction(options.level) ? options.level(req, res, err) : options.level;
 
         if (!options.skip(req, res, err)) {
-          // This is fire and forget, we don't want logging to hold up the request so don't wait for the callback
-          options.winstonInstance.log({
-            level,
-            message: template({err: err, req: req, res: res}),
-            meta: exceptionMeta
-          });
+            // This is fire and forget, we don't want logging to hold up the request so don't wait for the callback
+            options.winstonInstance.log(_.merge(exceptionMeta, {
+                level,
+                message: template({ err: err, req: req, res: res }),
+            }));
         }
 
         next(err);
@@ -220,12 +241,12 @@ exports.errorLogger = function errorLogger(options) {
 
 function levelFromStatus(options) {
     return function (req, res) {
-        var level = "";
-        if (res.statusCode >= 100) { level = options.statusLevels.success || "info"; }
-        if (res.statusCode >= 400) { level = options.statusLevels.warn || "warn"; }
-        if (res.statusCode >= 500) { level = options.statusLevels.error || "error"; }
+        var level = '';
+        if (res.statusCode >= 100) { level = options.statusLevels.success || 'info'; }
+        if (res.statusCode >= 400) { level = options.statusLevels.warn || 'warn'; }
+        if (res.statusCode >= 500) { level = options.statusLevels.error || 'error'; }
         return level;
-    }
+    };
 }
 
 //
@@ -246,23 +267,25 @@ exports.logger = function logger(options) {
     options.responseFilter = options.responseFilter || exports.defaultResponseFilter;
     options.ignoredRoutes = options.ignoredRoutes || exports.ignoredRoutes;
     options.winstonInstance = options.winstonInstance || (winston.createLogger({
-      transports: options.transports,
-      format: options.format
+        transports: options.transports,
+        format: options.format
     }));
     options.statusLevels = options.statusLevels || false;
-    options.level = options.statusLevels ? levelFromStatus(options) : (options.level || "info");
-    options.msg = options.msg || "HTTP {{req.method}} {{req.url}}";
+    options.level = options.statusLevels ? levelFromStatus(options) : (options.level || 'info');
+    options.msg = options.msg || 'HTTP {{req.method}} {{req.url}}';
     options.baseMeta = options.baseMeta || {};
-    options.metaField = options.metaField || null;
+    options.metaField = options.metaField === null || options.metaField === 'null' ? null : options.metaField || 'meta';
     options.colorize = options.colorize || false;
     options.expressFormat = options.expressFormat || false;
     options.ignoreRoute = options.ignoreRoute || function () { return false; };
     options.skip = options.skip || exports.defaultSkip;
-    options.dynamicMeta = options.dynamicMeta || function(req, res) { return null; };
+    options.dynamicMeta = options.dynamicMeta || function (req, res) { return null; };
+    options.requestField = options.requestField === null || options.requestField === 'null' ? null : options.requestField || exports.requestField;
+    options.responseField = options.responseField === null || options.responseField === 'null' ? null : options.responseField || exports.responseField;
 
     // Using mustache style templating
     var template = getTemplate(options, {
-      interpolate: /\{\{(.+?)\}\}/g
+        interpolate: /\{\{(.+?)\}\}/g
     });
 
     return function (req, res, next) {
@@ -286,7 +309,7 @@ exports.logger = function logger(options) {
 
         // Manage to get information from the response too, just like Connect.logger does:
         var end = res.end;
-        res.end = function(chunk, encoding) {
+        res.end = function (chunk, encoding) {
             res.responseTime = (new Date) - req._startTime;
 
             res.end = end;
@@ -296,87 +319,109 @@ exports.logger = function logger(options) {
 
             var meta = {};
 
-            if(options.meta !== false) {
-              var logData = {};
+            if (options.meta !== false) {
+                var logData = {};
 
-              var requestWhitelist = options.requestWhitelist.concat(req._routeWhitelists.req || []);
-              var responseWhitelist = options.responseWhitelist.concat(req._routeWhitelists.res || []);
+                if (options.requestField !== null) {
+                    var requestWhitelist = options.requestWhitelist.concat(req._routeWhitelists.req || []);
+                    var filteredRequest = filterObject(req, requestWhitelist, options.headerBlacklist, options.requestFilter);
 
-              logData.res = res;
+                    var bodyWhitelist = _.union(options.bodyWhitelist, (req._routeWhitelists.body || []));
+                    var blacklist = _.union(options.bodyBlacklist, (req._routeBlacklists.body || []));
 
-              if (_.includes(responseWhitelist.map(term => term.split('.')[0]), 'body')) {
-                if (chunk) {
-                  var isJson = (res.getHeader('content-type')
-                    && res.getHeader('content-type').indexOf('json') >= 0);
+                    var filteredBody = null;
 
-                  logData.res.body = bodyToString(chunk, isJson);
+                    if (req.body !== undefined) {
+                        if (blacklist.length > 0 && bodyWhitelist.length === 0) {
+                            var whitelist = _.difference(Object.keys(req.body), blacklist);
+                            filteredBody = filterObject(req.body, whitelist, options.headerBlacklist, options.requestFilter);
+                        } else if (
+                            requestWhitelist.indexOf('body') !== -1 &&
+                            bodyWhitelist.length === 0 &&
+                            blacklist.length === 0
+                        ) {
+                            filteredBody = filterObject(req.body, Object.keys(req.body), options.headerBlacklist, options.requestFilter);
+                        } else {
+                            filteredBody = filterObject(req.body, bodyWhitelist, options.headerBlacklist, options.requestFilter);
+                        }
+                    }
+
+                    if (filteredRequest) {
+                        if (filteredBody) {
+                            filteredRequest.body = filteredBody;
+                        } else {
+                            delete filteredRequest.body;
+                        }
+                    }
+
+                    logData[options.requestField] = filteredRequest;
                 }
-              }
 
-              logData.req = filterObject(req, requestWhitelist, options.headerBlacklist, options.requestFilter);
-              logData.res = filterObject(res, responseWhitelist, options.headerBlacklist, options.responseFilter);
+                var responseWhitelist = options.responseWhitelist.concat(req._routeWhitelists.res || []);
+                if (_.includes(responseWhitelist, 'body')) {
+                    if (chunk) {
+                        var isJson = (res.getHeader('content-type')
+                            && res.getHeader('content-type').indexOf('json') >= 0);
+                        const body = chunk.toString();
+                        res.body = bodyToString(body, isJson);
+                    }
+                }
 
-              var bodyWhitelist = _.union(options.bodyWhitelist, (req._routeWhitelists.body || []));
-              var blacklist = _.union(options.bodyBlacklist, (req._routeBlacklists.body || []));
+                if (options.responseField !== null) {
+                    var filteredResponse = filterObject(res, responseWhitelist, options.headerBlacklist, options.responseFilter);
+                    if (filteredResponse) {
+                        if (options.requestField === options.responseField) {
+                            logData[options.requestField] = _.assign(filteredRequest, filteredResponse);
+                        } else {
+                            logData[options.responseField] = filteredResponse;
+                        }
+                    }
+                }
 
-              var filteredBody = null;
+                if (!responseWhitelist.includes('responseTime')) {
+                    logData.responseTime = res.responseTime;
+                }
 
-              if ( req.body !== undefined ) {
-                  if (blacklist.length > 0 && bodyWhitelist.length === 0) {
-                    var whitelist = _.difference(Object.keys(req.body), blacklist);
-                    filteredBody = filterObject(req.body, whitelist, options.headerBlacklist, options.requestFilter);
-                  } else if (
-                    requestWhitelist.indexOf('body') !== -1 &&
-                    bodyWhitelist.length === 0 &&
-                    blacklist.length === 0
-                  ) {
-                    filteredBody = filterObject(req.body, Object.keys(req.body), options.headerBlacklist, options.requestFilter);
-                  } else {
-                    filteredBody = filterObject(req.body, bodyWhitelist, options.headerBlacklist, options.requestFilter);
-                  }
-              }
+                if (options.dynamicMeta) {
+                    var dynamicMeta = options.dynamicMeta(req, res);
+                    logData = _.assign(logData, dynamicMeta);
+                }
 
-              if (logData.req) {
-                if (filteredBody) {
-                  logData.req.body = filteredBody;
+                meta = _.assign(meta, logData);
+            }
+
+            if (options.metaField) {
+                var fields;
+                if (Array.isArray(options.metaField)) {
+                    fields = options.metaField;
                 } else {
-                  delete logData.req.body;
+                    fields = options.metaField.split('.');
                 }
-              }
-
-              logData.responseTime = res.responseTime;
-
-              if(options.dynamicMeta) {
-                  var dynamicMeta = options.dynamicMeta(req, res);
-                  logData = _.assign(logData, dynamicMeta);
-              }
-
-              if (options.metaField) {
-                  var newMeta = {};
-                  newMeta[options.metaField] = logData;
-                  logData = newMeta;
-              }
-              meta = _.assign(meta, logData);
+                _(fields).reverse().forEach(field => {
+                    var newMeta = {};
+                    newMeta[field] = meta;
+                    meta = newMeta;
+                });
             }
 
             meta = _.assign(meta, options.baseMeta);
 
             if (options.colorize) {
-              // Palette from https://github.com/expressjs/morgan/blob/master/index.js#L205
-              var statusColor = 'green';
-              if (res.statusCode >= 500) statusColor = 'red';
-              else if (res.statusCode >= 400) statusColor = 'yellow';
-              else if (res.statusCode >= 300) statusColor = 'cyan';
+                // Palette from https://github.com/expressjs/morgan/blob/master/index.js#L205
+                var statusColor = 'green';
+                if (res.statusCode >= 500) statusColor = 'red';
+                else if (res.statusCode >= 400) statusColor = 'yellow';
+                else if (res.statusCode >= 300) statusColor = 'cyan';
 
-              coloredRes.statusCode = chalk[statusColor](res.statusCode);
+                coloredRes.statusCode = chalk[statusColor](res.statusCode);
             }
 
-            var msg = template({req: req, res: _.assign({}, res, coloredRes)});
+            var msg = template({ req: req, res: _.assign({}, res, coloredRes) });
 
             // This is fire and forget, we don't want logging to hold up the request so don't wait for the callback
             if (!options.skip(req, res)) {
-              var level = _.isFunction(options.level) ? options.level(req, res) : options.level;
-              options.winstonInstance.log({level, message: msg, meta});
+                var level = _.isFunction(options.level) ? options.level(req, res) : options.level;
+                options.winstonInstance.log(_.merge(meta, { level, message: msg }));
             }
         };
 
@@ -401,17 +446,17 @@ function bodyToString(body, isJSON) {
 }
 
 function ensureValidOptions(options) {
-    if(!options) throw new Error("options are required by express-winston middleware");
-    if(!((options.transports && (options.transports.length > 0)) || options.winstonInstance))
-        throw new Error("transports or a winstonInstance are required by express-winston middleware");
+    if (!options) throw new Error('options are required by express-winston middleware');
+    if (!((options.transports && (options.transports.length > 0)) || options.winstonInstance))
+        throw new Error('transports or a winstonInstance are required by express-winston middleware');
 
     if (options.dynamicMeta && !_.isFunction(options.dynamicMeta)) {
-        throw new Error("`dynamicMeta` express-winston option should be a function");
+        throw new Error('`dynamicMeta` express-winston option should be a function');
     }
 }
 
 function ensureValidLoggerOptions(options) {
     if (options.ignoreRoute && !_.isFunction(options.ignoreRoute)) {
-        throw new Error("`ignoreRoute` express-winston option should be a function");
+        throw new Error('`ignoreRoute` express-winston option should be a function');
     }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.1",
+    "@types/logform": "^1.2.0",
     "eslint": "^5.16.0",
     "mocha": "^5.2.0",
     "node-mocks-http": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lodash": "^4.17.10"
   },
   "devDependencies": {
+    "@types/express": "^4.17.1",
     "eslint": "^5.16.0",
     "mocha": "^5.2.0",
     "node-mocks-http": "^1.5.1",
@@ -87,5 +88,6 @@
       "email": "yinzara@gmail.com",
       "url": "https://github.com/yinzara"
     }
-  ]
+  ],
+  "types": "index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "middleware",
     "colors"
   ],
-  "version": "3.3.0",
+  "version": "4.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/bithavoc/express-winston.git"
@@ -50,6 +50,15 @@
   "engines": {
     "node": ">= 6"
   },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "AUTHORS",
+    "LICENSE",
+    "CHANGELOG.md",
+    "Readme.md",
+    ".npmrc"
+  ],
   "license": "MIT",
   "contributors": [
     {
@@ -72,6 +81,11 @@
       "name": "Robbie Trencheny",
       "email": "me@robbiet.us",
       "url": "http://robbie.io"
+    },
+    {
+      "name": "Matt Morrissette",
+      "email": "yinzara@gmail.com",
+      "url": "https://github.com/yinzara"
     }
   ]
 }

--- a/test/express-winston-tests.ts
+++ b/test/express-winston-tests.ts
@@ -1,0 +1,103 @@
+// Not actually used for tests. Used to test the `index.d.ts` typescript definition matches known examples
+
+import expressWinston = require('..');
+import * as winston from 'winston';
+import express = require('express');
+import { Format } from 'logform';
+
+const app = express();
+
+// Logger with all options
+app.use(expressWinston.logger({
+    baseMeta: { foo: 'foo', nested: { bar: 'baz' } },
+    bodyBlacklist: ['foo'],
+    bodyWhitelist: ['bar'],
+    colorize: true,
+    dynamicMeta: (req, res, err) => ({ foo: 'bar' }),
+    expressFormat: true,
+    format: new Format(),
+    ignoreRoute: (req, res) => true,
+    ignoredRoutes: ['foo'],
+    level: (req, res) => 'level',
+    meta: true,
+    metaField: 'metaField',
+    msg: 'msg',
+    requestFilter: (req, prop) => req[prop],
+    requestWhitelist: ['foo', 'bar'],
+    skip: (req, res) => false,
+    statusLevels: ({ error: 'error', success: 'success', warn: 'warn' }),
+    transports: [
+        new winston.transports.Console({})
+    ]
+}));
+
+// Logger with minimum options (transport)
+app.use(expressWinston.logger({
+    transports: [
+        new winston.transports.Console({})
+    ],
+}));
+
+const logger = winston.createLogger();
+
+// Logger with minimum options (winstonInstance)
+app.use(expressWinston.logger({
+    winstonInstance: logger,
+}));
+
+// Error Logger with all options
+app.use(expressWinston.errorLogger({
+    baseMeta: { foo: 'foo', nested: { bar: 'baz' } },
+    dynamicMeta: (req, res, err) => ({ foo: 'bar' }),
+    format: new Format(),
+    level: (req, res) => 'level',
+    metaField: 'metaField',
+    msg: 'msg',
+    requestFilter: (req, prop) => true,
+    requestWhitelist: ['foo', 'bar'],
+    transports: [
+        new winston.transports.Console({})
+    ]
+}));
+
+// Error Logger with min options (transports)
+app.use(expressWinston.errorLogger({
+    transports: [
+        new winston.transports.Console({})
+    ],
+}));
+
+// Error Logger with min options (winstonInstance)
+app.use(expressWinston.errorLogger({
+    winstonInstance: logger,
+}));
+
+// Request and error logger with function type msg
+app.use(expressWinston.logger({
+    msg: (req, res) => `HTTP ${req.method} ${req.url} - ${res.statusCode}`,
+    transports: [
+        new winston.transports.Console({})
+    ],
+}));
+
+app.use(expressWinston.errorLogger({
+    msg: (req, res) => `HTTP ${req.method} ${req.url} - ${res.statusCode}`,
+    winstonInstance: logger,
+}));
+
+expressWinston.bodyBlacklist.push('potato');
+expressWinston.bodyWhitelist.push('apple');
+expressWinston.defaultRequestFilter = (req: expressWinston.FilterRequest, prop: string) => req[prop];
+expressWinston.defaultResponseFilter = (res: expressWinston.FilterResponse, prop: string) => res[prop];
+expressWinston.defaultSkip = () => true;
+expressWinston.ignoredRoutes.push('/ignored');
+expressWinston.responseWhitelist.push('body');
+
+const router = express.Router();
+
+router.post('/user/register', (req, res, next) => {
+    const expressWinstonReq = req as expressWinston.ExpressWinstonRequest;
+    expressWinstonReq._routeWhitelists.body = ['username', 'email', 'age'];
+    expressWinstonReq._routeWhitelists.req = ['userId'];
+    expressWinstonReq._routeWhitelists.res = ['_headers'];
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "test/express-winston-tests.ts"
+    ]
+}


### PR DESCRIPTION
This PR was created primarily for full support of using this library with `@google-cloud/logging-winston` on Google Cloud Logging (StackDriver).  Google has requirements about where an error stack trace and http request must be stored in the log entry and the current `express-winston` library does not allow it.

This PR includes a single BREAKING CHANGE related to the "metaField" option.  See Readme for details of upgrade requirements.

This PR adds/fixes the following functionality (all summed up in the Readme).
1. "metaField" now allows storing metadata at log entry root by setting its value to "null"
2. added "requestField" and "responseField" options
3. fix implementation of "meta" option in the `errorLogger` function
4. Added `.editorconfig` which matched best to the current style and performed a code reformat of the 'test.js' and 'index.js'
5. Add TypeScript typings to the library so it isn't necessary to add a devDependency to @types/express-winston