### PR TITLE
Update license year range

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2014 Bithavoc.io - http://bithavoc.io
+Copyright (c) 2012 Bithavoc.io - http://bithavoc.io
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Readme.md
+++ b/Readme.md
@@ -461,7 +461,7 @@ Also see AUTHORS file, add yourself if you are missing.
 
 ## MIT License
 
-Copyright (c) 2012-2014 Bithavoc.io and Contributors - http://bithavoc.io
+Copyright (c) 2012 Bithavoc.io and Contributors - http://bithavoc.io
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
```
Copyright (c) [year] [fullname]
```

[year] is the year copyright was applied. If you apply the copyright (which happens automatically when you write the work) in 2012, put in 2012. Though some projects uses a range of years (i.e. 2012-2019), but it is neither necessary nor effective (as it obviously requires edition of license EVERY new years.) (ref: https://opensource.stackexchange.com/questions/1522/what-should-be-written-in-mit-license-year-full-name)

However, this PR just respect your preference, so updated the year range to `2012 - 2019`. But I personally strongly recommend just fix it to 2012 if you think it's rational.