### PR TITLE
Adding `headerBlacklist` in LoggerOption interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,7 @@ export interface BaseLoggerOptions {
     requestWhitelist?: string[];
     responseFilter?: ResponseFilter;
     responseWhitelist?: string[];
+    headerBlacklist?: string[];
     skip?: RouteFilter;
     statusLevels?: {
         error?: string;


### PR DESCRIPTION
A small change required to use `headerBlacklist` in TypeScript Files, because currently not avaible in the TS interface of `BaseLoggerOptions`

Issue raised in #227.

Related to the wonderful PR #217. Probably, was missed there. So adding it in!