### PR TITLE
Add blacklist fields to BaseErrorLoggerOptions interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,6 +76,8 @@ export interface BaseErrorLoggerOptions {
     msg?: MessageTemplate;
     requestFilter?: RequestFilter;
     requestWhitelist?: string[];
+    headerBlacklist?: string[];
+    blacklistedMetaFields?: string[];
 }
 
 export interface ErrorLoggerOptionsWithTransports extends BaseErrorLoggerOptions {


### PR DESCRIPTION
Related to https://github.com/bithavoc/express-winston/pull/228

I want to use these options in TypeScript. Please add it.

- headerBlacklist
- blacklistedMetaFields