### PR TITLE
Extend Request type with responseTime and body

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,8 +17,24 @@ export interface FilterResponse extends Response {
     [other: string]: any;
 }
 
-export type DynamicMetaFunction = (req: Request, res: Response, err: Error) => object;
-export type DynamicLevelFunction = (req: Request, res: Response, err: Error) => string;
+export interface ExpressWinstonRequest extends Request {
+    _routeWhitelists: {
+        body: string[];
+        req: string[];
+        res: string[];
+    };
+}
+
+export interface ExpressWinstonResponse extends Response {
+    responseTime: number;
+    body?: string | Record<string, any>;
+}
+
+export type DynamicMetaFunction = (req: Request, res: ExpressWinstonResponse, err: Error) => Record<string, any>;
+export type DynamicLevelFunction = (req: Request, res: ExpressWinstonResponse, err: Error) => string;
+export type DynamicMetaFunctionError = (req: Request, res: Response, err: Error) => Record<string, any>;
+export type DynamicLevelFunctionError = (req: Request, res: Response, err: Error) => string;
+
 export type RequestFilter = (req: FilterRequest, propName: string) => any;
 export type ResponseFilter = (res: FilterResponse, propName: string) => any;
 export type RouteFilter = (req: Request, res: Response) => boolean;
@@ -67,9 +83,9 @@ export function logger(options: LoggerOptions): Handler;
 
 export interface BaseErrorLoggerOptions {
     baseMeta?: object;
-    dynamicMeta?: DynamicMetaFunction;
+    dynamicMeta?: DynamicMetaFunctionError;
     format?: Format;
-    level?: string | DynamicLevelFunction;
+    level?: string | DynamicLevelFunctionError;
     meta?: boolean;
     metaField?: string;
     requestField?: string;
@@ -107,11 +123,3 @@ export let defaultRequestFilter: RequestFilter;
 export let defaultResponseFilter: ResponseFilter;
 
 export function defaultSkip(): boolean;
-
-export interface ExpressWinstonRequest extends Request {
-    _routeWhitelists: {
-        body: string[];
-        req: string[];
-        res: string[];
-    };
-}


### PR DESCRIPTION
The logger middleware alters the response object, so that its type is not exactly like the pure Express request. This leads to errors if you're using `res.responseTime` or `res.body` in your own `dynamicMeta`. I have created a type `ExpressWinstonResponse` which includes these two fields.

I have also made the `DynamicMetaFunction` use this new ExpressWinstonResponse type. But I had to split it, as the _error_ middleware's response does not have a responseTime or body. So the type for `dynamicMeta` is different for the error middleware and the standard middleware.

I have also replace `object` with `Record<string, any>` as the return type for `dynamicMeta`. This is because if `object` is used, TypeScript does not allow you to add properties to the returned object.