### PR TITLE
Add missing exceptionToMeta and skip to TypeScript definition

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -124,8 +124,8 @@ The logger needs to be added AFTER the express router(`app.router)`) and BEFORE 
     baseMeta: Object, // default meta data to be added to log, this will be merged with the error data.
     meta: Boolean, // control whether you want to log the meta data about the request (default to true).
     metaField: String, // if defined, the meta data will be added in this field instead of the meta root object. Defaults to 'meta'. Set to `null` to store metadata at the root of the log entry.
-    requestField: [String] // the property of the metadata to store the request under (default 'req'). Set to null to exclude request from metadata
-    responseField: [String] // the property of the metadata to store the response under (default 'res'). If set to the same as 'requestField', filtered response and request properties will be merged. Set to null to exclude request from metadata    
+    requestField: [String] // the property of the metadata to store the request under (default 'req'). Set to null to exclude request from metadata    
+    responseField: [String] // the property of the metadata to store the response under (default 'res'). If set to the same as 'requestField', filtered response and request properties will be merged. Set to null to exclude request from metadata
     requestFilter: function (req, propName) { return req[propName]; } // A function to filter/return request values, defaults to returning all values allowed by whitelist. If the function returns undefined, the key/value will not be included in the meta.
     requestWhitelist: [String] // Array of request properties to log. Overrides global requestWhitelist for this instance
     headerBlacklist: [String], // Array of headers to omit from logs. Applied after any previous filters.

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,11 +17,13 @@ export interface FilterResponse extends Response {
     [other: string]: any;
 }
 
+export type ExceptionToMetaFunction = (err: Error) => object;
 export type DynamicMetaFunction = (req: Request, res: Response, err: Error) => object;
 export type DynamicLevelFunction = (req: Request, res: Response, err: Error) => string;
 export type RequestFilter = (req: FilterRequest, propName: string) => any;
 export type ResponseFilter = (res: FilterResponse, propName: string) => any;
 export type RouteFilter = (req: Request, res: Response) => boolean;
+export type ErrorRouteFilter = (req: Request, res: Response, err: Error) => boolean;
 export type MessageTemplate = string | ((req: Request, res: Response) => string);
 
 export interface BaseLoggerOptions {
@@ -68,16 +70,19 @@ export function logger(options: LoggerOptions): Handler;
 export interface BaseErrorLoggerOptions {
     baseMeta?: object;
     dynamicMeta?: DynamicMetaFunction;
+    exceptionToMeta?: ExceptionToMetaFunction;
     format?: Format;
     level?: string | DynamicLevelFunction;
     meta?: boolean;
     metaField?: string;
     requestField?: string;
+    responseField?: string;
     msg?: MessageTemplate;
     requestFilter?: RequestFilter;
     requestWhitelist?: string[];
     headerBlacklist?: string[];
     blacklistedMetaFields?: string[];
+    skip?: ErrorRouteFilter;
 }
 
 export interface ErrorLoggerOptionsWithTransports extends BaseErrorLoggerOptions {

--- a/test/express-winston-tests.ts
+++ b/test/express-winston-tests.ts
@@ -49,12 +49,19 @@ app.use(expressWinston.logger({
 app.use(expressWinston.errorLogger({
     baseMeta: { foo: 'foo', nested: { bar: 'baz' } },
     dynamicMeta: (req, res, err) => ({ foo: 'bar' }),
+    exceptionToMeta: function(error){return {}; },
     format: new Format(),
     level: (req, res) => 'level',
+    meta: true,
     metaField: 'metaField',
+    requestField: 'requestField',
+    responseField: 'responseField',
     msg: 'msg',
     requestFilter: (req, prop) => true,
     requestWhitelist: ['foo', 'bar'],
+    headerBlacklist: ['foo', 'bar'],
+    blacklistedMetaFields: ['foo', 'bar'],
+    skip: (req, res) => false,
     transports: [
         new winston.transports.Console({})
     ]


### PR DESCRIPTION
While using this package with Nest.js, I realized there was no `ignoreRoutes` option on the `errorLogger`. However, the `exceptionToMeta` and `skip` options are available, but were missing from the TypeScript definition.

- [x] Add missing `exceptionToMeta` and `skip` from `errorLogger` options to TypeScript definition
- [x] Update `express-winston-test.ts` file with new options