### PR TITLE
Allow filter out whitelisted request body

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,7 @@ export interface BaseLoggerOptions {
     headerBlacklist?: string[];
     skip?: RouteFilter;
     statusLevels?: Boolean | StatusLevels;
+    allowFilterOutWhitelistedRequestBody?: boolean;
 }
 
 export interface LoggerOptionsWithTransports extends BaseLoggerOptions {

--- a/index.js
+++ b/index.js
@@ -282,6 +282,7 @@ exports.logger = function logger(options) {
     options.dynamicMeta = options.dynamicMeta || function (req, res) { return null; };
     options.requestField = options.requestField === null || options.requestField === 'null' ? null : options.requestField || exports.requestField;
     options.responseField = options.responseField === null || options.responseField === 'null' ? null : options.responseField || exports.responseField;
+    options.allowFilterOutWhitelistedRequestBody = !!options.allowFilterOutWhitelistedRequestBody || false;
 
     // Using mustache style templating
     var template = getTemplate(options, {
@@ -346,7 +347,7 @@ exports.logger = function logger(options) {
                         }
                     }
 
-                    if (filteredRequest) {
+                    if (filteredRequest && (!options.allowFilterOutWhitelistedRequestBody || filteredRequest.body !== undefined)) {
                         if (filteredBody) {
                             filteredRequest.body = filteredBody;
                         } else {

--- a/test/test.js
+++ b/test/test.js
@@ -1508,6 +1508,33 @@ describe('express-winston', function () {
         loggerFn.should.throw();
       });
     });
+
+    describe('allowFilterOutWhitelistedRequestBody option', function() {
+      const removeRequestBodyFilter = (req, propName) => {
+        return (propName !== 'body') ? req[propName] : undefined;
+      };
+      const options = {
+        req: {
+          body: {
+            content: 'sensitive'
+          }
+        },
+        loggerOptions: {
+          requestWhitelist: ['body', 'url'],
+          requestFilter: removeRequestBodyFilter
+        }
+      };
+      it('should not filter out request whitelisted body using requestFilter when option missing', function() {
+        return loggerTestHelper(options).then(function (result) {
+          result.log.meta.req.should.have.property('body');
+        });
+      });
+      it('should filter out request whitelisted body using requestFilter when option exists', function() {
+        return loggerTestHelper(_.extend(options, { loggerOptions: _.extend(options.loggerOptions, { allowFilterOutWhitelistedRequestBody: true }) })).then(function (result) {
+          result.log.meta.req.should.not.have.property('body');
+        });
+      });
+    });
   });
 
   describe('.requestWhitelist', function () {


### PR DESCRIPTION
Using `requestFilter` and only if a special new option is set (In order to prevent breaking change)