### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -363,7 +363,7 @@ app.use(expressWinston.logger({
         httpRequest.remoteIp = req.ip.indexOf(':') >= 0 ? req.ip.substring(req.ip.lastIndexOf(':') + 1) : req.ip   // just ipv4
         httpRequest.requestSize = req.socket.bytesRead
         httpRequest.userAgent = req.get('User-Agent')
-        httpRequest.referrer = req.get('Referrer')
+        httpRequest.referer = req.get('Referrer')
       }
     
       if (res) {


### PR DESCRIPTION
`referrer` won't get logged in the httpRequest. The documentation shows the spelling to use is `referer` (https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry)

In express, it seems that either are acceptable looking at their docs (http://expressjs.com/en/api.html)
Snippet: `The Referrer and Referer fields are interchangeable.`