### PR TITLE
Github Actions + new PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Description
+
+<replace this with a brief description of the changes>
+
+### Risk/Impact Analysis
+
+<replace this with your assessment of the overall risk and impact of the changes to the project>
+
+### QA Notes
+
+<replace this with any additional information necessary to aid in testing the changes>

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,44 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [6.x, 8.x, 10.x, 12.x, 14.x]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v1
+      - name: set up node ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: install dependencies
+        working-directory: .
+        run: npm install
+      - name: running lint (pretest)
+        working-directory: .
+        run: npm run pretest
+
+  unit_tests:
+    name: unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [6.x, 8.x, 10.x, 12.x, 14.x]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v1
+      - name: set up node ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: install dependencies
+        working-directory: .
+        run: npm install
+      - name: running npm test
+        working-directory: .
+        run: npm run test


### PR DESCRIPTION
### Description

I wrote a quick github action workflow that will run lint and tests for all the versions the previous travis one did. 
I outlined some benefits in https://github.com/bithavoc/express-winston/issues/272 to do this, as well as the need to get the CI working again for PR contributions. 

**About Github Actions** 

Once merged they will start running on all pushed commits to PRs. 
I only added CI in this PR for introduction and to get it working on other PRs. It will run through a matrix of the node versions and perform both a lint/test on each. (maybe dont need to lint each version...)

- You can read more about Github Actions at the [documentation reference here.](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) 
- There is also a robust peer reviewed [marketplace](https://github.com/marketplace?type=actions) of open source resources that help to create more scalable CI solutions quickly. It also is more friendly for maintaining collaboratively compared to making a team on travis and sharing permissions. 

**About Github PR Template**

Really simple, just provides a default PR description so you can structure how contributions are formed. It also facilitates notes that can help the PR reviewer. 

The structure is markdown and i included 3 simple sections and invisible descriptions that are a good start. They can evolve over time depending on how you want to change them, but importantly having the file there allows others to change it. 

- There is a good explanation of setting it up [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository). 



### Risk/Impact Analysis

Low Risk / Non-code changes

### QA Notes

Setup a new workflow, or authorize me to setup the workflow in the settings of the repo. 

We will need a followup ticket which i can outline in https://github.com/bithavoc/express-winston/issues/272, which will publish to NPM on merges into main. 



