### PR TITLE
allow adding "req._routeBlacklists.res" in custom routes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,17 @@
 
 [CALL FOR MAINTAINERS](https://github.com/bithavoc/express-winston/issues/192)
 
+
+## IMPORTANT UPDATES TO THIS PACAKGE
+
+the us of below code is now valid in the routes
+
+```
+req._routeBlacklists.res=['body']
+```
+
+you can use this to ignore logging of response body in some specific routes due to a binary response or anything els.
+
 ## Installation
 
     npm install winston express-winston

--- a/index.js
+++ b/index.js
@@ -359,7 +359,8 @@ exports.logger = function logger(options) {
                 }
 
                 var responseWhitelist = options.responseWhitelist.concat(req._routeWhitelists.res || []);
-                if (_.includes(responseWhitelist, 'body')) {
+                var responseBlacklist = req._routeBlacklists.res || [];
+                if (_.includes(responseWhitelist, 'body') && !_.includes(responseBlacklist, 'body')) {
                     if (chunk) {
                         var isJson = (res.getHeader('content-type')
                             && res.getHeader('content-type').indexOf('json') >= 0);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "email": "im@bithavoc.io",
     "url": "http://bithavoc.io"
   },
-  "name": "express-winston",
+  "name": "@mahmoodels/express-winston",
   "description": "express.js middleware for winstonjs/winston",
   "keywords": [
     "winston",
@@ -19,7 +19,7 @@
   "version": "4.2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bithavoc/express-winston.git"
+    "url": "https://github.com/mhelal0/express-winston.git"
   },
   "bugs": {
     "url": "http://github.com/bithavoc/express-winston/issues",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "middleware",
     "colors"
   ],
-  "version": "4.2.0",
+  "version": "4.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/mhelal0/express-winston.git"


### PR DESCRIPTION
by using the below code you will not be able to exclude some responses body 
`expressWinston.responseWhitelist.push('body');`

we have to have the option to exclude the binary response because it will cause the error "STRING_TOO_LONG" and memory leak

so I just added the option to accept a black list of specific routes
