### PR TITLE
Allow dynamic meta to access blacklisted headers before they are removed from the payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -323,6 +323,11 @@ exports.logger = function logger(options) {
             if (options.meta !== false) {
                 var logData = {};
 
+                if (options.dynamicMeta) {
+                    var dynamicMeta = options.dynamicMeta(req, res);
+                    logData = _.assign(logData, dynamicMeta);
+                }
+
                 if (options.requestField !== null) {
                     var requestWhitelist = options.requestWhitelist.concat(req._routeWhitelists.req || []);
                     var filteredRequest = filterObject(req, requestWhitelist, options.headerBlacklist, options.requestFilter);
@@ -381,11 +386,6 @@ exports.logger = function logger(options) {
 
                 if (!responseWhitelist.includes('responseTime')) {
                     logData.responseTime = res.responseTime;
-                }
-
-                if (options.dynamicMeta) {
-                    var dynamicMeta = options.dynamicMeta(req, res);
-                    logData = _.assign(logData, dynamicMeta);
                 }
 
                 meta = _.assign(meta, logData);


### PR DESCRIPTION
Allow a caller to access information from a value before it is removed by the logger blacklist.

The use case is decoding a JWT, and getting the content from it. But not wanting to log the token itself.
The auth token is blacklisted to stop it being written out to the log, but the user id and roles are pulled from it first. 

No new code, just changing the order or the code execution. 